### PR TITLE
[API Improvement] Implement ToMessage for Command and Message and use ToMessage in Connection

### DIFF
--- a/src/data/message.rs
+++ b/src/data/message.rs
@@ -3,6 +3,14 @@
 use std::borrow::ToOwned;
 use std::str::FromStr;
 
+/// Represents something that can be converted to a message.
+pub trait ToMessage {
+
+    /// Convert to message.
+    fn to_message(&self) -> Message;
+
+}
+
 /// IRC Message data.
 #[experimental]
 #[deriving(Clone, PartialEq, Show)]
@@ -52,6 +60,14 @@ impl Message {
         ret.push_str("\r\n");
         ret
     }
+}
+
+impl ToMessage for Message {
+
+    fn to_message(&self) -> Message {
+        self.clone()
+    }
+
 }
 
 impl FromStr for Message {


### PR DESCRIPTION
Hello! I wanted to simplify the API of the `send` method to be simpler. I didn't like having to use `to_message` after creating a command, so now the library does it. I was inspired by [ToSocketAddr](http://doc.rust-lang.org/std/io/net/ip/trait.ToSocketAddr.html) which allows you to convert a bunch of things into a `SocketAddr`. Essentially, `send` now takes a `ToMessage` trait, and anything can implement that and be converted to a `Message`. The old API isn't broken as long as `ToMessage` is imported (althought `to_message` is used twice).

```rust
// new way
c.send(NICK("bob"));
// old way, still works
c.send(NICK("bob").to_message());
```

Also sorry about the diff, my editor removed trailing white space here and there.