### PR TITLE
Add nochanlists feature.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,6 +16,7 @@ default = ["ctcp", "encode", "ssl"]
 ctcp = ["time"]
 encode = ["encoding"]
 ssl = ["openssl"]
+nochanlists = []
 
 [dependencies.rustc-serialize]
 rustc-serialize = "~0.2.7"


### PR DESCRIPTION
This feature will disable user tracking including joins, parts, and modes.  This is useful for bots on severely crowded channels (tens of thousands of users) that have no need for maintaining a list of users.