### PR TITLE
Added config support to set umodes on connect.

### DIFF
--- a/src/client/data/config.rs
+++ b/src/client/data/config.rs
@@ -29,6 +29,8 @@ pub struct Config {
     /// The bot's real name.
     #[stable]
     pub realname: Option<String>,
+    /// User modes to set on connect. Example: "+RB-x"
+    pub umodes: Option<String>,
     /// The server to connect to.
     #[stable]
     pub server: Option<String>,
@@ -119,6 +121,13 @@ impl Config {
         self.realname.as_ref().map(|s| &s[]).unwrap_or(self.nickname())
     }
 
+    /// Gets the user modes set on connect specified in the configuration.
+    /// This defaults to an empty string when not specified.
+    #[stable]
+    pub fn umodes(&self) -> &str {
+        self.umodes.as_ref().map(|s| &s[]).unwrap_or("")
+    }
+
     /// Gets the address of the server specified in the configuration.
     /// This panics when not specified.
     #[stable]
@@ -197,6 +206,7 @@ mod test {
             username: Some(format!("test")),
             realname: Some(format!("test")),
             password: Some(String::new()),
+            umodes: Some(format!("+BR")),
             server: Some(format!("irc.test.net")),
             port: Some(6667),
             use_ssl: Some(false),
@@ -217,6 +227,7 @@ mod test {
             alt_nicks: None,
             username: Some(format!("test")),
             realname: Some(format!("test")),
+            umodes: Some(format!("+BR")),
             password: Some(String::new()),
             server: Some(format!("irc.test.net")),
             port: Some(6667),

--- a/src/client/server/mod.rs
+++ b/src/client/server/mod.rs
@@ -6,7 +6,7 @@ use std::old_io::{BufferedReader, BufferedWriter, IoError, IoErrorKind, IoResult
 use std::sync::{Mutex, RwLock};
 use client::conn::{Connection, NetStream};
 use client::data::{Command, Config, Message, Response, User};
-use client::data::Command::{JOIN, NICK, NICKSERV, PONG};
+use client::data::Command::{JOIN, NICK, NICKSERV, PONG, MODE};
 use client::data::kinds::{IrcReader, IrcWriter};
 #[cfg(feature = "ctcp")] use time::now;
 
@@ -146,6 +146,10 @@ impl<T: IrcReader, U: IrcWriter> IrcServer<T, U> {
                     self.send(NICKSERV(
                         &format!("IDENTIFY {}", self.config.nick_password())[]
                     )).unwrap();
+                }
+                if self.config.umodes() != "" {
+                    self.send(MODE(
+                        self.config.nickname(), self.config.umodes(), None)).unwrap();
                 }
                 for chan in self.config.channels().into_iter() {
                     self.send(JOIN(&chan[], None)).unwrap();


### PR DESCRIPTION
I am writing a simple, small bot using this library and noticed there was no config setting to choose which user-modes are set on connect. I think this fits well in the config section (eggdrop does the same thing iirc).

This patch adds a "umodes" field to the Config structure. The modes are set after the bot identifies on the server.