### PR TITLE
Command iterator.

### DIFF
--- a/examples/simple_cmd.rs
+++ b/examples/simple_cmd.rs
@@ -1,0 +1,43 @@
+extern crate irc;
+
+use std::default::Default;
+use irc::client::prelude::*;
+use irc::client::data::message::ToMessage;
+
+// This is the same as simple.rs, except we use an Iterator over Commands
+// instead of an Iterator over Messages. A Command is basically a parsed Message,
+// so Commands and Messages are interchangeable. It is up to the library user to
+// choose one.
+
+fn main() {
+    let config = Config {
+        nickname: Some(format!("pickles")),
+        alt_nicks: Some(vec![format!("bananas"), format!("apples")]),
+        server: Some(format!("irc.fyrechat.net")),
+        channels: Some(vec![format!("#vana")]),
+        .. Default::default()
+    };
+    let irc_server = IrcServer::from_config(config).unwrap();
+    // The wrapper provides us with methods like send_privmsg(...) and identify(...)
+    let server = Wrapper::new(&irc_server);     
+    server.identify().unwrap();
+    for command in server.iter_cmd() {
+        // Ignore errors
+        // Use of unwrap() with iter_cmd() is discouraged because iter_cmd() is still unstable
+        // and has trouble converting some custom Messages into Commands
+        match command {
+            Ok(cmd) => {
+                print!("{}", cmd.to_message().into_string());
+                match cmd {
+                    Command::PRIVMSG(target, text) => {
+                        if text[..].contains("pickles") {
+                            server.send_privmsg(&target[..], "Hi!").unwrap();
+                        }
+                    },
+                    _ => ()
+                }
+            },
+            Err(_) => ()
+        };
+    }
+}

--- a/src/client/data/command.rs
+++ b/src/client/data/command.rs
@@ -1145,6 +1145,12 @@ impl Command {
             return Err(invalid_input())
         })
     }
+
+    /// Converts an `IoResult<Message>` holding a Message into an `IoResult<Command>`
+    #[unstable = "This feature is still relatively new."]
+    pub fn from_message_io(m: IoResult<Message>) -> IoResult<Command> {
+        m.and_then(|msg| Command::from_message(&msg))
+    }
 }
 
 /// A list of all of the subcommands for the capabilities extension.

--- a/src/client/server/utils.rs
+++ b/src/client/server/utils.rs
@@ -9,7 +9,7 @@ use client::data::Command::{OPER, PASS, PONG, PRIVMSG, QUIT, SAMODE, SANICK, TOP
 use client::data::command::CapSubCommand::{END, REQ};
 use client::data::kinds::{IrcReader, IrcWriter};
 #[cfg(feature = "ctcp")] use time::get_time;
-use client::server::{Server, ServerIterator};
+use client::server::{Server, ServerIterator, ServerCmdIterator};
 
 /// Functionality-providing wrapper for Server.
 /// Wrappers are currently not thread-safe, and should be created per-thread, as needed.
@@ -29,6 +29,10 @@ impl<'a, T: IrcReader, U: IrcWriter> Server<'a, T, U> for Wrapper<'a, T, U> {
 
     fn iter(&'a self) -> ServerIterator<'a, T, U> {
         self.server.iter()
+    }
+
+    fn iter_cmd(&'a self) -> ServerCmdIterator<'a, T, U> {
+        self.server.iter_cmd()
     }
 
     fn list_users(&self, chan: &str) -> Option<Vec<User>> {


### PR DESCRIPTION
This patch adds a new iterator type, ServerCmdIterator, that yields Commands instead of Messages.

It also adds a new example showing how to use it, and a brief unit test.