### PR TITLE
Document state of server module

### DIFF
--- a/src/server/mod.rs
+++ b/src/server/mod.rs
@@ -1,1 +1,3 @@
 //! A simple, thread-safe IRC server library.
+//! The server module is currently unimplimented. Visit 
+//! https://github.com/aatxe/irc/issues/22 to contribute!


### PR DESCRIPTION
I was looking up how to do basic IRC stuff in Rust and found my way to http://aatxe.github.io/irc/irc/server/index.html and spent an embarrassing number of minutes trying to figure out why the docs weren't displaying. Turns out there weren't supposed to be any docs. This change will prevent such confusion in anyone else who finds these docs the way I did. 