### PR TITLE
User idents and hostnames actually can have dots

### DIFF
--- a/src/client/data/message.rs
+++ b/src/client/data/message.rs
@@ -34,12 +34,14 @@ impl Message {
 
     /// Gets the nickname of the message source, if it exists.
     pub fn source_nickname(&self) -> Option<&str> {
+        // <prefix> ::= <servername> | <nick> [ '!' <user> ] [ '@' <host> ]
+        // <servername> ::= <host>
         self.prefix.as_ref().and_then(|s|
             match (s.find('!'), s.find('@'), s.find('.')) {
-                (_, _, Some(_)) => None,
-                (Some(i), _, None) => Some(&s[..i]),
-                (None, Some(i), None) => Some(&s[..i]),
-                (None, None, None) => Some(&s)
+                (Some(i), _, _) => Some(&s[..i]), // nick!user
+                (None, Some(i), _) => Some(&s[..i]), // nick@host
+                (None, None, None) => Some(&s), // nick
+                _ => None // server.name
             }
         )
     }

--- a/src/client/data/message.rs
+++ b/src/client/data/message.rs
@@ -141,15 +141,31 @@ mod test {
         assert_eq!(Message::new(
             None, "PING", vec![], Some("data")
         ).unwrap().source_nickname(), None);
+
         assert_eq!(Message::new(
             Some("irc.test.net"), "PING", vec![], Some("data")
         ).unwrap().source_nickname(), None);
+
         assert_eq!(Message::new(
             Some("test!test@test"), "PING", vec![], Some("data")
         ).unwrap().source_nickname(), Some("test"));
+
         assert_eq!(Message::new(
             Some("test@test"), "PING", vec![], Some("data")
         ).unwrap().source_nickname(), Some("test"));
+
+        assert_eq!(Message::new(
+            Some("test!test@awe.did.you.know.irc.hostnames.have.dots"), "PING", vec![], Some("data")
+        ).unwrap().source_nickname(), Some("test"));
+
+        assert_eq!(Message::new(
+            Some("test!test@127.0.0.1"), "PING", vec![], Some("data")
+        ).unwrap().source_nickname(), Some("test"));
+
+        assert_eq!(Message::new(
+            Some("test@test.com"), "PING", vec![], Some("data")
+        ).unwrap().source_nickname(), Some("test"));
+
         assert_eq!(Message::new(
             Some("test"), "PING", vec![], Some("data")
         ).unwrap().source_nickname(), Some("test"));


### PR DESCRIPTION
`awe!awe@admin.pdgn.co`