### PR TITLE
Remove unused imports and fix broken test

### DIFF
--- a/src/client/conn.rs
+++ b/src/client/conn.rs
@@ -231,12 +231,11 @@ impl Connection for MockConnection {
 }
 
 mod imp {
-    use std::io::prelude::*;
     use std::io::Result;
     use std::io::Error;
     use std::io::ErrorKind;
     use std::sync::Mutex;
-    #[cfg(feature = "encode")] use encoding::{DecoderTrap, EncoderTrap, Encoding};
+    #[cfg(feature = "encode")] use encoding::{DecoderTrap, EncoderTrap};
     #[cfg(feature = "encode")] use encoding::label::encoding_from_whatwg_label;
     use client::data::kinds::{IrcRead, IrcWrite};
 

--- a/src/client/server/mod.rs
+++ b/src/client/server/mod.rs
@@ -700,7 +700,7 @@ mod test {
     }
 
     #[test]
-    #[should_panic(message = "All specified nicknames were in use.")]
+    #[should_panic(expected = "All specified nicknames were in use or disallowed.")]
     fn ran_out_of_nicknames() {
         let value = ":irc.pdgn.co 433 * test :Nickname is already in use.\r\n\
                      :irc.pdgn.co 433 * test2 :Nickname is already in use.\r\n";


### PR DESCRIPTION
These were reported by Rust compiler. `should_panic` attribute is quite important, because fixing it revealed we had a broken test (messages were mismatched).