### PR TITLE
Add support for RPL_TOPICWHOTIME (numeric 333)

### DIFF
--- a/src/client/data/response.rs
+++ b/src/client/data/response.rs
@@ -77,6 +77,8 @@ make_response! {
     RPL_NOTOPIC         = 331,
     /// `332 <channel> :<topic>`
     RPL_TOPIC           = 332,
+    /// `333 <channel> <nick>!<user>@<host> <unix timestamp>`
+    RPL_TOPICWHOTIME    = 333,
     /// `341 <channel> <nick>`
     RPL_INVITING        = 341,
     /// `342 <user> :Summoning user to IRC`


### PR DESCRIPTION
While not mandated by any of the IRC RFCs, it is in wide-spread use, and there does not seem to be conflicting uses of the numeric.

Most refer to it as RPL_TOPICWHOTIME, but there are some who refer to it as RPL_TOPICTIME.