### PR TITLE
Finalize 0.13.3 release.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,9 +4,8 @@ sudo: false
 script:
   - chmod +x mktestconfig.sh
   - ./mktestconfig.sh
-  - cargo clean
   - cargo build --verbose
-  - rustdoc --test README.md -L target/debug/deps
+  - rustdoc --test README.md --extern irc=target/debug/libirc.rlib -L target/debug/deps
   - cargo test --verbose --features "toml yaml"
   - cargo test --doc
   - cargo test --verbose --no-default-features

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,6 +4,7 @@ sudo: false
 script:
   - chmod +x mktestconfig.sh
   - ./mktestconfig.sh
+  - cargo clean
   - cargo build --verbose
   - rustdoc --test README.md -L target/debug/deps
   - cargo test --verbose --features "toml yaml"

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,16 +1,13 @@
-env:
-  global:
-    - secure: aGzqk53//ZQmZ/7Eb8XtlUG3bmwmR5p+RCSqUEz0xUazsYAO0/NRYgEkebXpggvjQCaJFsWWNxfSq5+3bVa43boIChKzshkrqIvF6sO5RxMslNQbb4rabo4GadJYMMFmoG/3h1EwFk3pEsAorNC/M6VVuH9XLKD5dWgvefMqclc=
 language: rust
 rust: stable
 sudo: false
 script:
   - chmod +x mktestconfig.sh
   - ./mktestconfig.sh
-  - cargo build --verbose --features "toml yaml"
+  - cargo build --verbose
+  - rustdoc --test README.md -L target/debug/deps
   - cargo test --verbose --features "toml yaml"
   - cargo test --doc
-  - cargo build --verbose --no-default-features
   - cargo test --verbose --no-default-features
 notifications:
   email: false

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -18,7 +18,7 @@ possible for everyone, there are a few guidelines that we need contributors to f
     branch.
   * To quickly create a topic branch based on develop, run `git checkout -b
     fix/develop/my_contribution develop`. Please avoid working directly on the
-    `stable` branch, and keep direct work on `develop` only to small changes.
+    `stable` branch, and keep direct work on `develop` minor.
 * Make commits of logical and atomic units.
 * Check for unnecessary whitespace with `git diff --check` before committing.
 * Make sure you have added the necessary tests for your changes.
@@ -38,7 +38,7 @@ possible for everyone, there are a few guidelines that we need contributors to f
 
 * [Code of Conduct](https://github.com/aatxe/irc/blob/develop/CODE_OF_CONDUCT.md)
 * [the irc crate docs](https://docs.rs/irc)
-* #irc IRC channel on irc.mozilla.org
+* #rust-irc IRC channel on irc.mozilla.org
 
 ## Credits
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,46 @@
+# How to contribute
+
+Your contributions are essential for making the irc crate the best piece of software it could
+possibly be! We welcome contributions from programmers of all skill levels, and are happy to provide
+mentorship for new contributors working on bug fixes. To make the onboarding process as painless as
+possible for everyone, there are a few guidelines that we need contributors to follow.
+
+## Getting Started
+
+* Make sure you have a [GitHub account](https://github.com/signup/free).
+* Fork the repository on GitHub.
+
+## Making Changes
+
+* Create a topic branch from where you want to base your work.
+  * This is almost always the develop branch.
+  * Only target stable or a maintainer's feature branch if you are certain your fix must be on that
+    branch.
+  * To quickly create a topic branch based on develop, run `git checkout -b
+    fix/develop/my_contribution develop`. Please avoid working directly on the
+    `stable` branch, and keep direct work on `develop` only to small changes.
+* Make commits of logical and atomic units.
+* Check for unnecessary whitespace with `git diff --check` before committing.
+* Make sure you have added the necessary tests for your changes.
+* Run _all_ the tests to assure nothing else was accidentally broken using `cargo test`. You can
+  also run `cargo test --no-default-features`, but this is generally not relevant and will be
+  handled by our continuous integration tools.
+  * Some tests related to configurations will fail if you don't run the `mktestconfig.sh` script.
+
+## Submitting Changes
+
+* Push your changes to a topic branch in your fork of the repository.
+* Submit a pull request to the `aatxe/irc` repository.
+* Await maintainer feedback and continuous integration results.
+  * We make an effort to triage quickly, but patience is appreciated!
+
+## Additional Resources
+
+* [Code of Conduct](https://github.com/aatxe/irc/blob/develop/CODE_OF_CONDUCT.md)
+* [the irc crate docs](https://docs.rs/irc)
+* #irc IRC channel on irc.mozilla.org
+
+## Credits
+
+These contributing guidelines were inspired by the
+[Puppet contributor guidelines](https://github.com/puppetlabs/puppet/blob/master/CONTRIBUTING.md).

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "irc"
-version = "0.13.2"
+version = "0.13.3"
 description = "A simple, thread-safe, and async-friendly library for IRC clients."
 authors = ["Aaron Weiss <awe@pdgn.co>"]
 license = "MPL-2.0"

--- a/README.md
+++ b/README.md
@@ -171,7 +171,7 @@ Note that the formats are automatically determined based on the selected file ex
 tool should make it easy for users to migrate their old configurations to TOML.
 
 ## Contributing ##
-the irc crate is an free, open source library that relies on contributions from its maintainers,
+the irc crate is a free, open source library that relies on contributions from its maintainers,
 Aaron Weiss ([@aatxe][awe]) and Peter Atashian ([@retep998][bun]), as well as the broader Rust
 community. It's licensed under the Mozilla Public License 2.0 whose text can be found in
 `LICENSE.md`. To foster an inclusive community around the irc crate, we have adopted a Code of

--- a/README.md
+++ b/README.md
@@ -175,7 +175,8 @@ the irc crate is an free, open source library that relies on contributions from 
 Aaron Weiss ([@aatxe][awe]) and Peter Atashian ([@retep998][bun]), as well as the broader Rust
 community. It's licensed under the Mozilla Public License 2.0 whose text can be found in
 `LICENSE.md`. To foster an inclusive community around the irc crate, we have adopted a Code of
-Conduct whose text can be found in `CODE_OF_CONDUCT.md`.
+Conduct whose text can be found in `CODE_OF_CONDUCT.md`. You can find details about how to
+contribute in `CONTRIBUTING.md`.
 
 [awe]: https://github.com/aatxe/
 [bun]: https://github.com/retep998/

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# irc [![Build Status][ci-badge]][ci] [![Crates.io][cr-badge]][cr] [![Docs][doc-badge]][doc] [![Built with Spacemacs][bws]][sm]
+# the irc crate [![Build Status][ci-badge]][ci] [![Crates.io][cr-badge]][cr] [![Docs][doc-badge]][doc] [![Built with Spacemacs][bws]][sm]
 
 [ci-badge]: https://travis-ci.org/aatxe/irc.svg?branch=stable
 [ci]: https://travis-ci.org/aatxe/irc
@@ -33,7 +33,7 @@ use irc::client::prelude::*;
 
 fn main() {
     let cfg = Config {
-        nickname: Some(format!("irc-rs")),
+        nickname: Some(format!("the-irc-crate")),
         client: Some(format!("irc.example.com")),
         channels: Some(vec![format!("#test")]),
         .. Default::default()
@@ -71,7 +71,7 @@ fn main() {
 
 ## Configuration ##
 
-Like the rest of the IRC crate, configuration is built with flexibility in mind. You can easily
+Like the rest of the irc crate, configuration is built with flexibility in mind. You can easily
 create `Config` objects programmatically and choose your own methods for handling any saving or
 loading of configuration required. However, for convenience, we've also included the option of
 loading files with `serde` to write configurations. The default configuration format is TOML,
@@ -97,7 +97,7 @@ cert_path = "cert.der"
 encoding = "UTF-8"
 channels = ["#rust", "#haskell", "#fake"]
 umodes = "+RB-x"
-user_info = "I'm a test user for the Rust IRC crate."
+user_info = "I'm a test user for the irc crate."
 version = "irc:git:Rust"
 source = "https://github.com/aatxe/irc"
 ping_time = 180

--- a/README.md
+++ b/README.md
@@ -154,7 +154,10 @@ tool should make it easy for users to migrate their old configurations to TOML.
 
 ## Contributing ##
 the irc crate is an free, open source library that relies on contributions from its maintainers,
-Aaron Weiss (@aatxe) and Peter Atashian (@retep998), as well as the broader Rust community. It's
-licensed under the Mozilla Public License 2.0 whose text can be found in `LICENSE.md`. To foster an
-inclusive community around the irc crate, we have adopted a Code of Conduct whose text can be found
-in `CODE_OF_CONDUCT.md`.
+Aaron Weiss ([@aatxe][awe]) and Peter Atashian ([@retep998][bun]), as well as the broader Rust
+community. It's licensed under the Mozilla Public License 2.0 whose text can be found in
+`LICENSE.md`. To foster an inclusive community around the irc crate, we have adopted a Code of
+Conduct whose text can be found in `CODE_OF_CONDUCT.md`.
+
+[awe]: https://github.com/aatxe/
+[bun]: https://github.com/retep998/

--- a/README.md
+++ b/README.md
@@ -18,6 +18,24 @@ compliant with [RFC 2812][rfc2812], [IRCv3.1][ircv3.1], [IRCv3.2][ircv3.2], and 
 additional, common features from popular IRCds. You can find up-to-date, ready-to-use documentation
 online [on docs.rs][doc].
 
+## Built with the irc crate ##
+
+the irc crate is being used to build new IRC software in Rust. Here are some of our favorite
+projects:
+
+- [alectro][alectro] — a terminal IRC client
+- [spilo][spilo] — a minimalistic IRC bouncer
+- [irc-bot.rs][ircbot] — a library for writing IRC bots
+- [bunnybutt-rs][bunnybutt] — an IRC bot for the [Feed The Beast Wiki][ftb-wiki]
+
+[alectro]: https://github.com/aatxe/alectro
+[spilo]: https://github.com/aatxe/spilo
+[ircbot]: https://github.com/8573/irc-bot.rs
+[bunnybutt]: https://github.com/FTB-Gamepedia/bunnybutt-rs
+[ftb-wiki]: https://ftb.gamepedia.com/FTB_Wiki
+
+Making your own project? [Submit a pull request](https://github.com/aatxe/irc/pulls) to add it!
+
 ## Getting Started ##
 
 To start using the irc crate with cargo, you can simply add `irc = "0.13"` to your dependencies in

--- a/src/client/mod.rs
+++ b/src/client/mod.rs
@@ -845,7 +845,7 @@ impl<'a> Future for IrcClientFuture<'a> {
     }
 }
 
-/// An `IrcClient` packaged with a future that drives its message sending. In order for the client 
+/// An `IrcClient` packaged with a future that drives its message sending. In order for the client
 /// to actually work properly, this future _must_ be running.
 ///
 /// This type should only be used by advanced users who are familiar with the implementation of this
@@ -861,6 +861,7 @@ mod test {
     use std::time::Duration;
 
     use super::{IrcClient, Client};
+    use error::IrcError;
     use client::data::Config;
     #[cfg(not(feature = "nochanlists"))]
     use client::data::User;
@@ -1054,11 +1055,11 @@ mod test {
         let res = client.for_each_incoming(|message| {
             println!("{:?}", message);
         });
-        use error::IrcError;
-        match res.expect_err("returned no error when no valid nicks were specified") {
-            IrcError::NoUsableNick => (),
-            _ => panic!("expected {} error when no valid nicks are specified"),
-
+       
+        if let Err(IrcError::NoUsableNick) = res {
+            ()
+        } else {
+            panic!("expected error when no valid nicks were specified")
         }
     }
 
@@ -1268,7 +1269,7 @@ mod test {
         assert_eq!(
             &get_client_value(client)[..],
             "NOTICE test :\u{001}SOURCE https://github.com/aatxe/irc\u{001}\r\n\
-         NOTICE test :\u{001}SOURCE\u{001}\r\n"
+             NOTICE test :\u{001}SOURCE\u{001}\r\n"
         );
     }
 

--- a/src/error.rs
+++ b/src/error.rs
@@ -91,6 +91,10 @@ pub enum IrcError {
         /// The data that failed to encode or decode.
         data: String,
     },
+
+    /// All specified nicks were in use or unusable.
+    #[fail(display = "no usable nicks")]
+    NoUsableNick
 }
 
 /// Errors that occur when parsing messages.

--- a/src/error.rs
+++ b/src/error.rs
@@ -92,8 +92,8 @@ pub enum IrcError {
         data: String,
     },
 
-    /// All specified nicks were in use or unusable.
-    #[fail(display = "no usable nicks")]
+    /// All specified nicknames were in use or unusable.
+    #[fail(display = "none of the specified nicknames were usable")]
     NoUsableNick
 }
 

--- a/src/proto/response.rs
+++ b/src/proto/response.rs
@@ -3,14 +3,16 @@
 use std::str::FromStr;
 
 macro_rules! make_response {
-    ($(#[$attr:meta] $variant:ident = $value:expr),+) => {
+    ($($(#[$attr:meta])+ $variant:ident = $value:expr),+) => {
         /// List of all server responses as defined in
-        /// [RFC 2812](http://tools.ietf.org/html/rfc2812).
-        /// All commands are documented with their expected form from the RFC.
+        /// [RFC 2812](http://tools.ietf.org/html/rfc2812) and
+        /// [Modern docs](https://modern.ircdocs.horse/#numerics) (henceforth referred to as
+        /// Modern). All commands are documented with their expected form from the RFC, and any
+        /// useful, additional information about the response code.
         #[derive(Clone, Copy, Debug, PartialEq)]
         #[repr(u16)]
         pub enum Response {
-            $(#[$attr] $variant = $value),+
+            $($(#[$attr])+ $variant = $value),+
         }
 
         impl Response {
@@ -27,334 +29,380 @@ macro_rules! make_response {
 
 make_response! {
     // Expected replies
-    /// `001 Welcome to the Internet Relay Network <nick>!<user>@<host>`
+    /// `001 Welcome to the Internet Relay Network <nick>!<user>@<host>` (Source: RFC2812)
     RPL_WELCOME         =   1,
-    /// `002 Your host is <servername>, running version <ver>`
+    /// `002 Your host is <servername>, running version <ver>` (Source: RFC2812)
     RPL_YOURHOST        =   2,
-    /// `003 This server was created <date>`
+    /// `003 This server was created <date>` (Source: RFC2812)
     RPL_CREATED         =   3,
-    /// `004 <servername> <version> <available user modes> available channel modes>`
+    /// `004 <servername> <version> <available user modes> <available channel modes>` (Source:
+    /// RFC2812)
+    ///
+    /// Various IRCds may choose to include additional arguments to `RPL_MYINFO`, and it's best to
+    /// check for certain what the servers you're targeting do. Typically, there are additional
+    /// parameters at the end for modes that have parameters, and server modes.
     RPL_MYINFO          =   4,
-    /// `005 <servername> *(<feature>(=<value>)) :are supported by this server`
+    /// `005 <servername> *(<feature>(=<value>)) :are supported by this server` (Source: Modern)
+    ///
+    /// [RPL_ISUPPORT](https://modern.ircdocs.horse/#rplisupport-005) replaces RPL_BOUNCE from
+    /// RFC2812, but does so consistently in modern IRCd implementations. RPL_BOUNCE has been moved
+    /// to `010`.
     RPL_ISUPPORT        =   5,
-    /// `010 Try server <server name>, port <port number>`
+    /// `010 Try server <server name>, port <port number>` (Source: Modern)
     RPL_BOUNCE          =  10,
-    /// `302 :*1<reply> *( " " <reply> )`
+    /// Undefined format. (Source: Modern)
+    ///
+    /// RPL_NONE is a dummy numeric. It does not have a defined use nor format. 
+    RPL_NONE            = 300,
+    /// `302 :*1<reply> *( " " <reply> )` (Source: RFC2812)
     RPL_USERHOST        = 302,
-    /// `303 :*1<nick> *( " " <nick> )`
+    /// `303 :*1<nick> *( " " <nick> )` (Source: RFC2812)
     RPL_ISON            = 303,
-    /// `301 <nick> :<away message>`
+    /// `301 <nick> :<away message>` (Source: RFC2812)
     RPL_AWAY            = 301,
-    /// `305 :You are no longer marked as being away`
+    /// `305 :You are no longer marked as being away` (Source: RFC2812)
     RPL_UNAWAY          = 305,
-    /// `306 :You have been marked as being away`
+    /// `306 :You have been marked as being away` (Source: RFC2812)
     RPL_NOWAWAY         = 306,
-    /// `311 <nick> <user> <host> * :<real name>`
+    /// `311 <nick> <user> <host> * :<real name>` (Source: RFC2812)
     RPL_WHOISUSER       = 311,
-    /// `312 <nick> <server> :<server info>`
+    /// `312 <nick> <server> :<server info>` (Source: RFC2812)
     RPL_WHOISSERVER     = 312,
-    /// `313 <nick> :is an IRC operator`
+    /// `313 <nick> :is an IRC operator` (Source: RFC2812)
     RPL_WHOISOPERATOR   = 313,
-    /// `317 <nick> <integer> :seconds idle`
+    /// `317 <nick> <integer> :seconds idle` (Source: RFC2812)
     RPL_WHOISIDLE       = 317,
-    /// `318 <nick> :End of WHOIS list`
+    /// `318 <nick> :End of WHOIS list` (Source: RFC2812)
     RPL_ENDOFWHOIS      = 318,
-    /// `319 <nick> :*( ( "@" / "+" ) <channel> " " )`
+    /// `319 <nick> :*( ( "@" / "+" ) <channel> " " )` (Source: RFC2812)
     RPL_WHOISCHANNELS   = 319,
-    /// `314 <nick> <user> <host> * :<real name>`
+    /// `314 <nick> <user> <host> * :<real name>` (Source: RFC2812)
     RPL_WHOWASUSER      = 314,
-    /// `369 <nick> :End of WHOWAS`
+    /// `369 <nick> :End of WHOWAS` (Source: RFC2812)
     RPL_ENDOFWHOWAS     = 369,
-    /// Obsolete. Not used.
+    /// Obsolete. Not used. (Source: RFC2812)
     RPL_LISTSTART       = 321,
-    /// `322 <channel> <# visible> :<topic>`
+    /// `322 <channel> <# visible> :<topic>` (Source: RFC2812)
     RPL_LIST            = 322,
-    /// `323 :End of LIST
+    /// `323 :End of LIST (Source: RFC2812)
     RPL_LISTEND         = 323,
-    /// `325 <channel> <nickname>`
+    /// `325 <channel> <nickname>` (Source: RFC2812)
     RPL_UNIQOPIS        = 325,
-    /// `324 <channel> <mode> <mode params>`
+    /// `324 <channel> <mode> <mode params>` (Source: RFC2812)
     RPL_CHANNELMODEIS   = 324,
-    /// `331 <channel> :No topic is set`
+    /// `331 <channel> :No topic is set` (Source: RFC2812)
     RPL_NOTOPIC         = 331,
-    /// `332 <channel> :<topic>`
+    /// `332 <channel> :<topic>` (Source: RFC2812)
     RPL_TOPIC           = 332,
-    /// `333 <channel> <nick>!<user>@<host> <unix timestamp>`
+    /// `333 <channel> <nick>!<user>@<host> <unix timestamp>` (Source: RFC2812)
     RPL_TOPICWHOTIME    = 333,
-    /// `341 <channel> <nick>`
+    /// `341 <channel> <nick>` (Source: RFC2812)
     RPL_INVITING        = 341,
-    /// `342 <user> :Summoning user to IRC`
+    /// `342 <user> :Summoning user to IRC` (Source: RFC2812)
+    ///
+    /// According to Modern, this response is rarely implemented. In practice, people simply message
+    /// one another in a channel with their specified username in the message, rather than use the
+    /// `SUMMON` command.
     RPL_SUMMONING       = 342,
-    /// `346 <channel> <invitemask>`
+    /// `346 <channel> <invitemask>` (Source: RFC2812)
     RPL_INVITELIST      = 346,
-    /// `347 <channel> :End of channel invite list`
+    /// `347 <channel> :End of channel invite list` (Source: RFC2812)
+    ///
+    /// According to Modern, `RPL_ENDOFEXCEPTLIST` (349) is frequently deployed for this same
+    /// purpose and the difference will be noted in channel mode and the statement in the suffix.
     RPL_ENDOFINVITELIST = 347,
-    /// `348 <channel> <exceptionmask>`
+    /// `348 <channel> <exceptionmask>` (Source: RFC2812)
     RPL_EXCEPTLIST      = 348,
-    /// `349 <channel> :End of channel exception list`
+    /// `349 <channel> :End of channel exception list` (Source: RFC2812)
     RPL_ENDOFEXCEPTLIST = 349,
-    /// `351 <version>.<debuglevel> <server> :<comments>`
+    /// `351 <version> <server> :<comments>` (Source: RFC2812/Modern)
     RPL_VERSION         = 351,
-    /** `352 <channel> <user> <host> <server> <nick> ( "H" / "G" > ["*"] [ ( "@" / "+" ) ]
-        :<hopcount> <real name>` **/
+    /// `352 <channel> <user> <host> <server> <nick> ( "H" / "G" > ["*"] [ ( "@" / "+" ) ]
+    /// :<hopcount> <real name>` (Source: RFC2812)
     RPL_WHOREPLY        = 352,
-    /// `315 <name> :End of WHO list`
+    /// `315 <name> :End of WHO list` (Source: RFC2812)
     RPL_ENDOFWHO        = 315,
     /// `353 ( "=" / "*" / "@" ) <channel> :[ "@" / "+" ] <nick> *( " " [ "@" / "+" ] <nick> )`
+    /// (Source: RFC2812)
     RPL_NAMREPLY        = 353,
-    /// `366 <channel> :End of NAMES list`
+    /// `366 <channel> :End of NAMES list` (Source: RFC2812)
     RPL_ENDOFNAMES      = 366,
-    /// `364 <mask> <server> :<hopcount> <server info>`
+    /// `364 <mask> <server> :<hopcount> <server info>` (Source: RFC2812)
     RPL_LINKS           = 364,
-    /// `365 <mask> :End of LINKS list`
+    /// `365 <mask> :End of LINKS list` (Source: RFC2812)
     RPL_ENDOFLINKS      = 365,
-    /// `367 <channel> <banmask>`
+    /// `367 <channel> <banmask>` (Source: RFC2812)
     RPL_BANLIST         = 367,
-    /// `368 <channel> :End of channel ban list`
+    /// `368 <channel> :End of channel ban list` (Source: RFC2812)
     RPL_ENDOFBANLIST    = 368,
-    /// `371 :<string>`
+    /// `371 :<string>` (Source: RFC2812)
     RPL_INFO            = 371,
-    /// `374 :End of INFO list`
+    /// `374 :End of INFO list` (Source: RFC2812)
     RPL_ENDOFINFO       = 374,
-    /// `375 :- <server> Message of the day -`
+    /// `375 :- <server> Message of the day -` (Source: RFC2812)
     RPL_MOTDSTART       = 375,
-    /// `372 :- <text>`
+    /// `372 :- <text>` (Source: RFC2812)
     RPL_MOTD            = 372,
-    /// `376 :End of MOTD command`
+    /// `376 :End of MOTD command` (Source: RFC2812)
     RPL_ENDOFMOTD       = 376,
-    /// `381 :You are now an IRC operator`
+    /// `381 :You are now an IRC operator` (Source: RFC2812)
     RPL_YOUREOPER       = 381,
-    /// `382 <config file> :Rehashing`
+    /// `382 <config file> :Rehashing` (Source: RFC2812)
     RPL_REHASHING       = 382,
-    /// `383 You are service <servicename>`
+    /// `383 You are service <servicename>` (Source: RFC2812)
     RPL_YOURESERVICE    = 383,
-    /// `391 <server> :<string showing server's local time>`
+    /// `391 <server> :<string showing server's local time>` (Source: RFC2812)
     RPL_TIME            = 391,
-    /// `392 :UserID   Terminal  Host`
+    /// `392 :UserID   Terminal  Host` (Source: RFC2812)
     RPL_USERSSTART      = 392,
-    /// `393 :<username> <ttyline> <hostname>`
+    /// `393 :<username> <ttyline> <hostname>` (Source: RFC2812)
     RPL_USERS           = 393,
-    /// `394 :End of users`
+    /// `394 :End of users` (Source: RFC2812)
     RPL_ENDOFUSERS      = 394,
-    /// `395 :Nobody logged in`
+    /// `395 :Nobody logged in` (Source: RFC2812)
     RPL_NOUSERS         = 395,
-    /** `200 Link <version & debug level> <destination> <next server> V<protocol version>
-        <link uptime in seconds> <backstream sendq> <upstream sendq>` **/
+    /// `396 <nickname> <host> :is now your displayed host` (Source: InspIRCd)
+    ///
+    /// This response code is sent after a user enables the user mode +x (host masking), and it is
+    /// successfully enabled. The particular format described above is from InspIRCd, but the
+    /// response code should be common amongst servers that support host masks.
+    RPL_HOSTHIDDEN      = 396,
+    /// `200 Link <version & debug level> <destination> <next server> V<protocol version>
+    /// <link uptime in seconds> <backstream sendq> <upstream sendq>` (Source: RFC2812)
     RPL_TRACELINK       = 200,
-    /// `201 Try. <class> <server>`
+    /// `201 Try. <class> <server>` (Source: RFC2812)
     RPL_TRACECONNECTING = 201,
-    /// `202 H.S. <class> <server>`
+    /// `202 H.S. <class> <server>` (Source: RFC2812)
     RPL_TRACEHANDSHAKE  = 202,
-    /// `203 ???? <class> [<client IP address in dot form>]`
+    /// `203 ???? <class> [<client IP address in dot form>]` (Source: RFC2812)
     RPL_TRACEUKNOWN     = 203,
-    /// `204 Oper <class> <nick>`
+    /// `204 Oper <class> <nick>` (Source: RFC2812)
     RPL_TRACEOPERATOR   = 204,
-    /// `205 User <class> <nick>`
+    /// `205 User <class> <nick>` (Source: RFC2812)
     RPL_TRACEUSER       = 205,
     /// `206 Serv <class> <int>S <int>C <server> <nick!user|*!*>@<host|server> V<protocol version>`
+    /// (Source: RFC2812)
     RPL_TRACESERVER     = 206,
-    /// `207 Service <class> <name> <type> <active type>`
+    /// `207 Service <class> <name> <type> <active type>` (Source: RFC2812)
     RPL_TRACESERVICE    = 207,
-    /// `208 <newtype> 0 <client name>`
+    /// `208 <newtype> 0 <client name>` (Source: RFC2812)
     RPL_TRACENEWTYPE    = 208,
-    /// `209 Class <class> <count>`
+    /// `209 Class <class> <count>` (Source: RFC2812)
     RPL_TRACECLASS      = 209,
-    /// Unused.
+    /// Unused. (Source: RFC2812)
     RPL_TRACERECONNECT  = 210,
-    /// `261 File <logfile> <debug level>`
+    /// `261 File <logfile> <debug level>` (Source: RFC2812)
     RPL_TRACELOG        = 261,
-    /// `262 <server name> <version & debug level> :End of TRACE`
+    /// `262 <server name> <version & debug level> :End of TRACE` (Source: RFC2812)
     RPL_TRACEEND        = 262,
-    /** `211 <linkname> <sendq> <sent messages> <sent Kbytes> <received messages> <received Kbytes>
-        <time open>` **/
+    /// `211 <linkname> <sendq> <sent messages> <sent Kbytes> <received messages> <received Kbytes>
+    /// <time open>` (Source: RFC2812)
     RPL_STATSLINKINFO   = 211,
-    /// `212 <command> <count> <byte count> <remote count>`
+    /// `212 <command> <count> <byte count> <remote count>` (Source: RFC2812)
     RPL_STATSCOMMANDS   = 212,
-    /// `219 <stats letter> :End of STATS report`
+    /// `219 <stats letter> :End of STATS report` (Source: RFC2812)
     RPL_ENDOFSTATS      = 219,
-    /// `242 :Server Up %d days %d:%02d:%02d`
+    /// `242 :Server Up %d days %d:%02d:%02d` (Source: RFC2812)
     RPL_STATSUPTIME     = 242,
-    /// `243 O <hostmask> * <name>`
+    /// `243 O <hostmask> * <name>` (Source: RFC2812)
     RPL_STATSOLINE      = 243,
-    /// `221 <user mode string>`
+    /// `221 <user mode string>` (Source: RFC2812)
     RPL_UMODEIS         = 221,
-    /// `234 <name> <server> <mask> <type> <hopcount> <info>`
+    /// `234 <name> <server> <mask> <type> <hopcount> <info>` (Source: RFC2812)
     RPL_SERVLIST        = 234,
-    /// `235 <mask> <type> :End of service listing`
+    /// `235 <mask> <type> :End of service listing` (Source: RFC2812)
     RPL_SERVLISTEND     = 235,
-    /// `251 :There are <integer> users and <integer> services on <integer> servers`
+    /// `251 :There are <int> users and <int> services on <int> servers` (Source: RFC2812)
     RPL_LUSERCLIENT     = 251,
-    /// `252 <integer> :operator(s) online`
+    /// `252 <integer> :operator(s) online` (Source: RFC2812)
     RPL_LUSEROP         = 252,
-    /// `253 <integer> :unknown connection(s)`
+    /// `253 <integer> :unknown connection(s)` (Source: RFC2812)
     RPL_LUSERUNKNOWN    = 253,
-    /// `254 <integer> :channels formed`
+    /// `254 <integer> :channels formed` (Source: RFC2812)
     RPL_LUSERCHANNELS   = 254,
-    /// `255 :I have <integer> clients and <integer> servers`
+    /// `255 :I have <integer> clients and <integer> servers` (Source: RFC2812)
     RPL_LUSERME         = 255,
-    /// `256 <server> :Administrative info`
+    /// `256 <server> :Administrative info` (Source: RFC2812)
     RPL_ADMINME         = 256,
-    /// `257 :<admin info>`
+    /// `257 :<admin info>` (Source: RFC2812)
     RPL_ADMINLOC1       = 257,
-    /// `258 :<admin info>`
+    /// `258 :<admin info>` (Source: RFC2812)
     RPL_ADMINLOC2       = 258,
-    /// `259 :<admin info>`
+    /// `259 :<admin info>` (Source: RFC2812)
     RPL_ADMINEMAIL      = 259,
-    /// `263 <command> :Please wait a while and try again.`
+    /// `263 <command> :Please wait a while and try again.` (Source: RFC2812)
     RPL_TRYAGAIN        = 263,
-    /// `730 <nick> :target[,target2]*`
+    /// `265 <client> [<u> <m>] :Current local users <u>, max <m>` (Source: Modern)
+    RPL_LOCALUSERS      = 265,
+    /// `266 <client> [<u> <m>] :Current local users <u>, max <m>` (Source: Modern)
+    RPL_GLOBALUSERS     = 266,
+    /// `276 <client> <nick> :has client certificate fingerprint <fingerprint>` (Source: Modern)
+    RPL_WHOISCERTFP     = 276,
+    /// `730 <nick> :target[,target2]*` (Source: RFC2812)
     RPL_MONONLINE       = 730,
-    /// `731 <nick> :target[,target2]*`
+    /// `731 <nick> :target[,target2]*` (Source: RFC2812)
     RPL_MONOFFLINE      = 731,
-    /// `732 <nick> :target[,target2]*`
+    /// `732 <nick> :target[,target2]*` (Source: RFC2812)
     RPL_MONLIST         = 732,
-    /// `733 <nick> :End of MONITOR list`
+    /// `733 <nick> :End of MONITOR list` (Source: RFC2812)
     RPL_ENDOFMONLIST    = 733,
-    /// `760 <target> <key> <visibility> :<value>`
+    /// `760 <target> <key> <visibility> :<value>` (Source: RFC2812)
     RPL_WHOISKEYVALUE   = 760,
-    /// `761 <target> <key> <visibility> :[<value>]`
+    /// `761 <target> <key> <visibility> :[<value>]` (Source: RFC2812)
     RPL_KEYVALUE        = 761,
-    /// `762 :end of metadata`
+    /// `762 :end of metadata` (Source: RFC2812)
     RPL_METADATAEND     = 762,
-    /// `900 <nick> <nick>!<ident>@<host> <account> :You are now logged in as <user>`
+    /// `900 <nick> <nick>!<ident>@<host> <account> :You are now logged in as <user>` (Source:
+    /// IRCv3)
     RPL_LOGGEDIN        = 900,
-    /// `901 <nick> <nick>!<ident>@<host> :You are now logged out`
+    /// `901 <nick> <nick>!<ident>@<host> :You are now logged out` (Source: IRCv3)
     RPL_LOGGEDOUT       = 901,
-    /// `903 <nick> :SASL authentication successful`
+    /// `903 <nick> :SASL authentication successful` (Source: IRCv3)
     RPL_SASLSUCCESS     = 903,
-    /// `908 <nick> <mechanisms> :are available SASL mechanisms`
+    /// `908 <nick> <mechanisms> :are available SASL mechanisms` (Source: IRCv3)
     RPL_SASLMECHS       = 908,
 
     // Error replies
-    /// `401 <nickname> :No such nick/channel`
+    /// `400 <client> <command>{ <subcommand>} :<info>` (Source: Modern)
+    ///
+    /// According to Modern, this error will be returned when the given command/subcommand could not
+    /// be processed. It's a very general error, and should only be used when more specific numerics
+    /// do not suffice.
+    ERR_UNKNOWNERROR        = 400,
+    /// `401 <nickname> :No such nick/channel` (Source: RFC2812)
     ERR_NOSUCHNICK          = 401,
-    /// `402 <server name> :No such server`
+    /// `402 <server name> :No such server` (Source: RFC2812)
     ERR_NOSUCHSERVER        = 402,
-    /// `403 <channel name> :No such channel`
+    /// `403 <channel name> :No such channel` (Source: RFC2812)
     ERR_NOSUCHCHANNEL       = 403,
-    /// `404 <channel name> :Cannot send to channel`
+    /// `404 <channel name> :Cannot send to channel` (Source: RFC2812)
     ERR_CANNOTSENDTOCHAN    = 404,
-    /// `405 <channel name> :You have joined too many channels`
+    /// `405 <channel name> :You have joined too many channels` (Source: RFC2812)
     ERR_TOOMANYCHANNELS     = 405,
-    /// `406 <nickname> :There was no such nickname`
+    /// `406 <nickname> :There was no such nickname` (Source: RFC2812)
     ERR_WASNOSUCHNICK       = 406,
-    /// `407 <target> :<error code> recipients. <abort message>`
+    /// `407 <target> :<error code> recipients. <abort message>` (Source: RFC2812)
     ERR_TOOMANYTARGETS      = 407,
-    /// `408 <service name> :No such service`
+    /// `408 <service name> :No such service` (Source: RFC2812)
     ERR_NOSUCHSERVICE       = 408,
-    /// `409 :No origin specified`
+    /// `409 :No origin specified` (Source: RFC2812)
     ERR_NOORIGIN            = 409,
-    /// `411 :No recipient given (<command>)`
+    /// `411 :No recipient given (<command>)` (Source: RFC2812)
     ERR_NORECIPIENT         = 411,
-    /// `412 :No text to send`
+    /// `412 :No text to send` (Source: RFC2812)
     ERR_NOTEXTTOSEND        = 412,
-    /// `413 <mask> :No toplevel domain specified`
+    /// `413 <mask> :No toplevel domain specified` (Source: RFC2812)
     ERR_NOTOPLEVEL          = 413,
-    /// `414 <mask> :Wildcard in toplevel domain`
+    /// `414 <mask> :Wildcard in toplevel domain` (Source: RFC2812)
     ERR_WILDTOPLEVEL        = 414,
-    /// `415 <mask> :Bad Server/host mask`
+    /// `415 <mask> :Bad Server/host mask` (Source: RFC2812)
     ERR_BADMASK             = 415,
-    /// `421 <command> :Unknown command`
+    /// `421 <command> :Unknown command` (Source: RFC2812)
     ERR_UNKNOWNCOMMAND      = 421,
-    /// `422 :MOTD File is missing`
+    /// `422 :MOTD File is missing` (Source: RFC2812)
     ERR_NOMOTD              = 422,
-    /// `423 <server> :No administrative info available`
+    /// `423 <server> :No administrative info available` (Source: RFC2812)
     ERR_NOADMININFO         = 423,
-    /// `424 :File error doing <file op> on <file>`
+    /// `424 :File error doing <file op> on <file>` (Source: RFC2812)
     ERR_FILEERROR           = 424,
-    /// `431 :No nickname given`
+    /// `431 :No nickname given` (Source: RFC2812)
     ERR_NONICKNAMEGIVEN     = 431,
-    /// `432 <nick> :Erroneous nickname"`
+    /// `432 <nick> :Erroneous nickname"` (Source: RFC2812)
     ERR_ERRONEOUSNICKNAME   = 432,
-    /// `433 <nick> :Nickname is already in use`
+    /// `433 <nick> :Nickname is already in use` (Source: RFC2812)
     ERR_NICKNAMEINUSE       = 433,
-    /// `436 <nick> :Nickname collision KILL from <user>@<host>`
+    /// `436 <nick> :Nickname collision KILL from <user>@<host>` (Source: RFC2812)
     ERR_NICKCOLLISION       = 436,
-    /// `437 <nick/channel> :Nick/channel is temporarily unavailable`
+    /// `437 <nick/channel> :Nick/channel is temporarily unavailable` (Source: RFC2812)
     ERR_UNAVAILRESOURCE     = 437,
-    /// `441 <nick> <channel> :They aren't on that channel`
+    /// `441 <nick> <channel> :They aren't on that channel` (Source: RFC2812)
     ERR_USERNOTINCHANNEL    = 441,
-    /// `442 <channel> :You're not on that channel`
+    /// `442 <channel> :You're not on that channel` (Source: RFC2812)
     ERR_NOTONCHANNEL        = 442,
-    /// `443 <user> <channel> :is already on channel`
+    /// `443 <user> <channel> :is already on channel` (Source: RFC2812)
     ERR_USERONCHANNEL       = 443,
-    /// `444 <user> :User not logged in`
+    /// `444 <user> :User not logged in` (Source: RFC2812)
     ERR_NOLOGIN             = 444,
-    /// `445 :SUMMON has been disabled`
+    /// `445 :SUMMON has been disabled` (Source: RFC2812)
     ERR_SUMMONDISABLED      = 445,
-    /// `446 :USERS has been disabled`
+    /// `446 :USERS has been disabled` (Source: RFC2812)
     ERR_USERSDISABLED       = 446,
-    /// `451 :You have not registered`
+    /// `451 :You have not registered` (Source: RFC2812)
     ERR_NOTREGISTERED       = 451,
-    /// `461 <command> :Not enough parameters`
+    /// `461 <command> :Not enough parameters` (Source: RFC2812)
     ERR_NEEDMOREPARAMS      = 461,
-    /// `462 :Unauthorized command (already registered)`
+    /// `462 :Unauthorized command (already registered)` (Source: RFC2812)
     ERR_ALREADYREGISTRED    = 462,
-    /// `463 :Your host isn't among the privileged`
+    /// `463 :Your host isn't among the privileged` (Source: RFC2812)
     ERR_NOPERMFORHOST       = 463,
-    /// `464 :Password incorrect`
+    /// `464 :Password incorrect` (Source: RFC2812)
     ERR_PASSWDMISMATCH      = 464,
-    /// `465 :You are banned from this server`
+    /// `465 :You are banned from this server` (Source: RFC2812)
     ERR_YOUREBANNEDCREEP    = 465,
-    /// `466`
+    /// `466` (Source: RFC2812)
     ERR_YOUWILLBEBANNED     = 466,
-    /// `467 <channel> :Channel key already set`
+    /// `467 <channel> :Channel key already set` (Source: RFC2812)
     ERR_KEYSET              = 467,
-    /// `471 <channel> :Cannot join channel (+l)`
+    /// `471 <channel> :Cannot join channel (+l)` (Source: RFC2812)
     ERR_CHANNELISFULL       = 471,
-    /// `472 <char> :is unknown mode char to me for <channel>`
+    /// `472 <char> :is unknown mode char to me for <channel>` (Source: RFC2812)
     ERR_UNKNOWNMODE         = 472,
-    /// `473 <channel> :Cannot join channel (+i)`
+    /// `473 <channel> :Cannot join channel (+i)` (Source: RFC2812)
     ERR_INVITEONLYCHAN      = 473,
-    /// `474 <channel> :Cannot join channel (+b)`
+    /// `474 <channel> :Cannot join channel (+b)` (Source: RFC2812)
     ERR_BANNEDFROMCHAN      = 474,
-    /// `475 <channel> :Cannot join channel (+k)`
+    /// `475 <channel> :Cannot join channel (+k)` (Source: RFC2812)
     ERR_BADCHANNELKEY       = 475,
-    /// `476 <channel> :Bad Channel Mask`
+    /// `476 <channel> :Bad Channel Mask` (Source: RFC2812)
     ERR_BADCHANMASK         = 476,
-    /// `477 <channel> :Channel doesn't support modes`
+    /// `477 <channel> :Channel doesn't support modes` (Source: RFC2812)
     ERR_NOCHANMODES         = 477,
-    /// `478 <channel> <char> :Channel list is full`
+    /// `478 <channel> <char> :Channel list is full` (Source: RFC2812)
     ERR_BANLISTFULL         = 478,
-    /// `481 :Permission Denied- You're not an IRC operator`
+    /// `481 :Permission Denied- You're not an IRC operator` (Source: RFC2812)
     ERR_NOPRIVILEGES        = 481,
-    /// `482 <channel> :You're not channel operator`
+    /// `482 <channel> :You're not channel operator` (Source: RFC2812)
     ERR_CHANOPRIVSNEEDED    = 482,
-    /// `483 :You can't kill a server!`
+    /// `483 :You can't kill a server!` (Source: RFC2812)
     ERR_CANTKILLSERVER      = 483,
-    /// `484 :Your connection is restricted!`
+    /// `484 :Your connection is restricted!` (Source: RFC2812)
     ERR_RESTRICTED          = 484,
-    /// `485 :You're not the original channel operator`
+    /// `485 :You're not the original channel operator` (Source: RFC2812)
     ERR_UNIQOPPRIVSNEEDED   = 485,
-    /// `491 :No O-lines for your host`
+    /// `491 :No O-lines for your host` (Source: RFC2812)
     ERR_NOOPERHOST          = 491,
-    /// `501 :Unknown MODE flag`
+    /// `501 :Unknown MODE flag` (Source: RFC2812)
     ERR_UMODEUNKNOWNFLAG    = 501,
-    /// `502 :Cannot change mode for other users`
+    /// `502 :Cannot change mode for other users` (Source: RFC2812)
     ERR_USERSDONTMATCH      = 502,
-    /// `734 <nick> <limit> <targets> :Monitor list is full.`
+    /// `723 <client> <priv> :Insufficient oper privileges.` (Source: Modern)
+    ///
+    /// Sent to an operator to indicate that they don't have the specific privileges to perform the
+    /// desired action. The format and meaning of the privilege string is server-defined.
+    ERR_NOPRIVS             = 723,
+    /// `734 <nick> <limit> <targets> :Monitor list is full.` (Source: RFC2812)
     ERR_MONLISTFULL         = 734,
-    /// `764 <target> :metadata limit reached`
+    /// `764 <target> :metadata limit reached` (Source: RFC2812)
     ERR_METADATALIMIT       = 764,
-    /// `765 <target> :invalid metadata target`
+    /// `765 <target> :invalid metadata target` (Source: RFC2812)
     ERR_TARGETINVALID       = 765,
-    /// `766 <key> :no matching key`
+    /// `766 <key> :no matching key` (Source: RFC2812)
     ERR_NOMATCHINGKEY       = 766,
-    /// `767 <key> :invalid metadata key`
+    /// `767 <key> :invalid metadata key` (Source: RFC2812)
     ERR_KEYINVALID          = 767,
-    /// `768 <target> <key> :key not set`
+    /// `768 <target> <key> :key not set` (Source: RFC2812)
     ERR_KEYNOTSET           = 768,
-    /// `769 <target> <key> :permission denied`
+    /// `769 <target> <key> :permission denied` (Source: RFC2812)
     ERR_KEYNOPERMISSION     = 769,
-    /// `902 <nick> :You must use a nick assigned to you.`
+    /// `902 <nick> :You must use a nick assigned to you.` (Source: IRCv3)
     ERR_NICKLOCKED          = 902,
-    /// `904 <nick> :SASL authentication failed`
+    /// `904 <nick> :SASL authentication failed` (Source: IRCv3)
     ERR_SASLFAIL            = 904,
-    /// `905 <nick> :SASL message too long`
+    /// `905 <nick> :SASL message too long` (Source: IRCv3)
     ERR_SASLTOOLONG         = 905,
-    /// `906 <nick> :SASL authentication aborted`
+    /// `906 <nick> :SASL authentication aborted` (Source: IRCv3)
     ERR_SASLABORT           = 906,
-    /// `907 <nick> :You have already authenticated using SASL`
+    /// `907 <nick> :You have already authenticated using SASL` (Source: IRCv3)
     ERR_SASLALREADY         = 907
 }
 

--- a/src/proto/response.rs
+++ b/src/proto/response.rs
@@ -408,6 +408,10 @@ make_response! {
 
 impl Response {
     /// Determines whether or not this response is an error response.
+    ///
+    /// This error consideration is according to RFC2812, but is rather simplistic. It considers all
+    /// response codes above 400 to be errors, which misclassifies some extensions (e.g. from IRCv3)
+    /// that add responses and errors both in the same range (typically 700s or 900s).
     pub fn is_error(&self) -> bool {
         *self as u16 >= 400
     }


### PR DESCRIPTION
Finalize 0.13.3 release.

Contents:

- Replaced a panic when `alt_nicks` is exhausted with proper error handling.
- Added additional popular response codes from various IRCds.
- Improved documentation for `Response` as part of #106.
- Fixed #115 where cleanly closed connections could cause `IrcReactor`s to run forever.
- Improved `README.md` and added `CONTRIBUTING.md` for contributor guidelines.
