### PR TITLE
Finalize 0.13.5 release.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "irc"
-version = "0.13.4"
+version = "0.13.5"
 description = "A simple, thread-safe, and async-friendly library for IRC clients."
 authors = ["Aaron Weiss <awe@pdgn.co>"]
 license = "MPL-2.0"

--- a/src/client/mod.rs
+++ b/src/client/mod.rs
@@ -847,7 +847,7 @@ mod test {
     #[cfg(not(feature = "nochanlists"))]
     use client::data::User;
     use proto::{ChannelMode, IrcCodec, Mode};
-    use proto::command::Command::{PART, PRIVMSG};
+    use proto::command::Command::{PART, PRIVMSG, Raw};
 
     pub fn test_config() -> Config {
         Config {
@@ -1070,6 +1070,18 @@ mod test {
                 .is_ok()
         );
         assert_eq!(&get_client_value(client)[..], "PRIVMSG #test :Hi there!\r\n");
+    }
+
+    #[test]
+    fn send_raw_is_really_raw() {
+        let client = IrcClient::from_config(test_config()).unwrap();
+        assert!(
+            client.send(Raw("PASS".to_owned(), vec!["password".to_owned()], None)).is_ok()
+        );
+        assert!(
+            client.send(Raw("NICK".to_owned(), vec!["test".to_owned()], None)).is_ok()
+        );
+        assert_eq!(&get_client_value(client)[..], "PASS password\r\nNICK test\r\n");
     }
 
     #[test]

--- a/src/proto/irc.rs
+++ b/src/proto/irc.rs
@@ -16,6 +16,22 @@ impl IrcCodec {
     pub fn new(label: &str) -> error::Result<IrcCodec> {
         LineCodec::new(label).map(|codec| IrcCodec { inner: codec })
     }
+
+    /// Sanitizes the input string by cutting up to (and including) the first occurence of a line
+    /// terminiating phrase (`\r\n`, `\r`, or `\n`). This is used in sending messages back to
+    /// prevent the injection of additional commands.
+    pub(crate) fn sanitize(mut data: String) -> String {
+        // n.b. ordering matters here to prefer "\r\n" over "\r"
+        if let Some((pos, len)) = ["\r\n", "\r", "\n"]
+            .iter()
+            .flat_map(|needle| data.find(needle).map(|pos| (pos, needle.len())))
+            .min_by_key(|&(pos, _)| pos)
+        {
+            data.truncate(pos + len);
+        }
+        data
+    }
+
 }
 
 impl Decoder for IrcCodec {
@@ -35,6 +51,6 @@ impl Encoder for IrcCodec {
 
 
     fn encode(&mut self, msg: Message, dst: &mut BytesMut) -> error::Result<()> {
-        self.inner.encode(msg.to_string(), dst)
+        self.inner.encode(IrcCodec::sanitize(msg.to_string()), dst)
     }
 }


### PR DESCRIPTION
Finalize 0.13.5 release.

Contents:
- Moved input sanitation into `IrcCodec` to prevent problematic parsing round-trips.
- Added regression tests for #128 which inspired the above change.