### PR TITLE
Remove unnecessary [..]

### DIFF
--- a/src/proto/colors.rs
+++ b/src/proto/colors.rs
@@ -102,10 +102,10 @@ impl FormattedStringExt for str {
 
 impl FormattedStringExt for String {
     fn is_formatted(&self) -> bool {
-        (&self[..]).is_formatted()
+        (&self).is_formatted()
     }
     fn strip_formatting(&self) -> Cow<str> {
-        (&self[..]).strip_formatting()
+        (&self).strip_formatting()
     }
 }
 


### PR DESCRIPTION
Replaces `(&self[..]).strip_formatting()` with `(&self).strip_formatting()` in `impl FormattedStringExt for String`