### PR TITLE
Migrated to `tokio` handleless runtime with `impl Future` result types.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -39,6 +39,7 @@ serde = "1.0"
 serde_derive = "1.0"
 serde_json = { version = "1.0", optional = true }
 serde_yaml = { version = "0.7", optional = true }
+tokio = "0.1"
 tokio-core = "0.1"
 tokio-io = "0.1"
 tokio-mockstream = "1.1"

--- a/README.md
+++ b/README.md
@@ -70,7 +70,7 @@ fn main() {
     };
 
     let mut reactor = IrcReactor::new().unwrap();
-    let client = reactor.prepare_client_and_connect(&config).unwrap();
+    let client = reactor.prepare_client_and_connect(config).unwrap();
     client.identify().unwrap();
     
     reactor.register_client_with_handler(client, |client, message| {

--- a/examples/multiserver.rs
+++ b/examples/multiserver.rs
@@ -26,7 +26,7 @@ fn main() {
     for config in configs {
         // Immediate errors like failure to resolve the server's domain or to establish any connection will
         // manifest here in the result of prepare_client_and_connect.
-        let client = reactor.prepare_client_and_connect(&config).unwrap();
+        let client = reactor.prepare_client_and_connect(config).unwrap();
         client.identify().unwrap();
         // Here, we tell the reactor to setup this client for future handling (in run) using the specified
         // handler function process_msg.

--- a/examples/reactor.rs
+++ b/examples/reactor.rs
@@ -14,7 +14,7 @@ fn main() {
     };
 
     let mut reactor = IrcReactor::new().unwrap();
-    let client = reactor.prepare_client_and_connect(&config).unwrap();
+    let client = reactor.prepare_client_and_connect(config).unwrap();
     client.identify().unwrap();
 
     reactor.register_client_with_handler(client, |client, message| {

--- a/examples/reconnector.rs
+++ b/examples/reconnector.rs
@@ -26,7 +26,7 @@ fn main() {
     loop {
         let res = configs.iter().fold(Ok(()), |acc, config| {
             acc.and(
-                reactor.prepare_client_and_connect(config).and_then(|client| {
+                reactor.prepare_client_and_connect(config.clone()).and_then(|client| {
                     client.identify().and(Ok(client))
                 }).and_then(|client| {
                     reactor.register_client_with_handler(client, process_msg);

--- a/src/client/conn.rs
+++ b/src/client/conn.rs
@@ -2,6 +2,7 @@
 use std::fs::File;
 use std::fmt;
 use std::io::Read;
+use std::net::SocketAddr;
 
 use encoding::EncoderTrap;
 use encoding::label::encoding_from_whatwg_label;
@@ -119,7 +120,7 @@ impl<'a> Future for ConnectionFuture<'a> {
 
 impl Connection {
     /// Creates a new `Connection` using the specified `Config` and `Handle`.
-    pub fn new<'a>(config: &'a Config) -> error::Result<ConnectionFuture<'a>> {
+    pub fn new<'a>(config: &'a Config) -> impl Future<Item = Connection, Error = error::IrcError> {
         if config.use_mock_connection() {
             Ok(ConnectionFuture::Mock(config))
         } else if config.use_ssl() {

--- a/src/client/conn.rs
+++ b/src/client/conn.rs
@@ -7,8 +7,7 @@ use encoding::EncoderTrap;
 use encoding::label::encoding_from_whatwg_label;
 use futures::{Async, Poll, Future, Sink, StartSend, Stream};
 use native_tls::{Certificate, TlsConnector, Pkcs12};
-use tokio_core::reactor::Handle;
-use tokio_core::net::{TcpStream, TcpStreamNew};
+use tokio::net::{ConnectFuture, TcpStream};
 use tokio_io::AsyncRead;
 use tokio_mockstream::MockStream;
 use tokio_tls::{TlsConnectorExt, TlsStream};
@@ -48,7 +47,7 @@ type TlsFuture = Box<Future<Error = error::IrcError, Item = TlsStream<TcpStream>
 /// A future representing an eventual `Connection`.
 pub enum ConnectionFuture<'a> {
     #[doc(hidden)]
-    Unsecured(&'a Config, TcpStreamNew),
+    Unsecured(&'a Config, ConnectFuture),
     #[doc(hidden)]
     Secured(&'a Config, TlsFuture),
     #[doc(hidden)]
@@ -120,7 +119,7 @@ impl<'a> Future for ConnectionFuture<'a> {
 
 impl Connection {
     /// Creates a new `Connection` using the specified `Config` and `Handle`.
-    pub fn new<'a>(config: &'a Config, handle: &Handle) -> error::Result<ConnectionFuture<'a>> {
+    pub fn new<'a>(config: &'a Config) -> error::Result<ConnectionFuture<'a>> {
         if config.use_mock_connection() {
             Ok(ConnectionFuture::Mock(config))
         } else if config.use_ssl() {
@@ -145,7 +144,7 @@ impl Connection {
                 info!("Using {} for client certificate authentication.", client_cert_path);
             }
             let connector = builder.build()?;
-            let stream = Box::new(TcpStream::connect(&config.socket_addr()?, handle).map_err(|e| {
+            let stream = Box::new(TcpStream::connect(&config.socket_addr()?).map_err(|e| {
                 let res: error::IrcError = e.into();
                 res
             }).and_then(move |socket| {
@@ -158,7 +157,7 @@ impl Connection {
             info!("Connecting to {}.", config.server()?);
             Ok(ConnectionFuture::Unsecured(
                 config,
-                TcpStream::connect(&config.socket_addr()?, handle),
+                TcpStream::connect(&config.socket_addr()?),
             ))
         }
     }

--- a/src/client/reactor.rs
+++ b/src/client/reactor.rs
@@ -70,7 +70,7 @@ impl IrcReactor {
     /// # }
     /// ```
     pub fn prepare_client<'a>(&mut self, config: &'a Config) -> error::Result<IrcClientFuture<'a>> {
-        IrcClient::new_future(self.inner_handle(), config)
+        IrcClient::new_future(config)
     }
 
     /// Runs an [`IrcClientFuture`](../struct.IrcClientFuture.html), such as one from

--- a/src/client/reactor.rs
+++ b/src/client/reactor.rs
@@ -16,7 +16,7 @@
 //! fn main() {
 //!   let config = Config::default();
 //!   let mut reactor = IrcReactor::new().unwrap();
-//!   let client = reactor.prepare_client_and_connect(&config).unwrap();
+//!   let client = reactor.prepare_client_and_connect(config).unwrap();
 //!   reactor.register_client_with_handler(client, process_msg);
 //!   reactor.run().unwrap();
 //! }
@@ -28,7 +28,7 @@ use futures::future;
 use tokio_core::reactor::{Core, Handle};
 
 use client::data::Config;
-use client::{IrcClient, IrcClientFuture, PackedIrcClient, Client};
+use client::{IrcClient, Client};
 use error;
 use proto::Message;
 
@@ -65,11 +65,11 @@ impl IrcReactor {
     /// # fn main() {
     /// # let config = Config::default();
     /// let future_client = IrcReactor::new().and_then(|mut reactor| {
-    ///     reactor.prepare_client(&config)
+    ///     Ok(reactor.prepare_client(config))
     /// });
     /// # }
     /// ```
-    pub fn prepare_client<'a>(&mut self, config: &'a Config) -> impl Future<
+    pub fn prepare_client(&mut self, config: Config) -> impl Future<
         Item = (IrcClient, impl Future<Item = (), Error = error::IrcError> + 'static),
         Error = error::IrcError
     > {
@@ -87,9 +87,8 @@ impl IrcReactor {
     /// # fn main() {
     /// # let config = Config::default();
     /// let client = IrcReactor::new().and_then(|mut reactor| {
-    ///     reactor.prepare_client(&config).and_then(|future| {
-    ///         reactor.connect_client(future)
-    ///     })
+    ///     let future = reactor.prepare_client(config);
+    ///     reactor.connect_client(future)
     /// });
     /// # }
     /// ```
@@ -116,11 +115,11 @@ impl IrcReactor {
     /// # fn main() {
     /// # let config = Config::default();
     /// let client = IrcReactor::new().and_then(|mut reactor| {
-    ///     reactor.prepare_client_and_connect(&config)
+    ///     reactor.prepare_client_and_connect(config)
     /// });
     /// # }
     /// ```
-    pub fn prepare_client_and_connect(&mut self, config: &Config) -> error::Result<IrcClient> {
+    pub fn prepare_client_and_connect(&mut self, config: Config) -> error::Result<IrcClient> {
         let client_future = self.prepare_client(config);
         self.connect_client(client_future)
     }
@@ -140,7 +139,7 @@ impl IrcReactor {
     /// # fn main() {
     /// # let config = Config::default();
     /// let mut reactor = IrcReactor::new().unwrap();
-    /// let client = reactor.prepare_client_and_connect(&config).unwrap();
+    /// let client = reactor.prepare_client_and_connect(config).unwrap();
     /// reactor.register_client_with_handler(client, |client, msg| {
     ///   // Message processing happens here.
     ///   Ok(())
@@ -186,7 +185,7 @@ impl IrcReactor {
     /// # fn main() {
     /// # let config = Config::default();
     /// let mut reactor = IrcReactor::new().unwrap();
-    /// let client = reactor.prepare_client_and_connect(&config).unwrap();
+    /// let client = reactor.prepare_client_and_connect(config).unwrap();
     /// reactor.register_client_with_handler(client, process_msg);
     /// reactor.run().unwrap();
     /// # }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -59,6 +59,7 @@ extern crate serde_derive;
 extern crate serde_json;
 #[cfg(feature = "yaml")]
 extern crate serde_yaml;
+extern crate tokio;
 extern crate tokio_core;
 extern crate tokio_io;
 extern crate tokio_mockstream;


### PR DESCRIPTION
Key features:

- Added dependency on `tokio` 0.1 - required by handle-less reactor/runtime inter-operation;

- Rewrote `IrcClient::new_future()` and `Connection::new()` to return an `impl Future`, not require a `Handle`, and take `Config` rather than `&Config` - the latter is due to a `'static` borrow that almost inevitably happens when working with futures in runtimes;

- Rewrote relevant methods in `reactor` module;

- Updated examples and tests to reflect the changes.

More detailed breakdown is in commit messages.

To be perfectly honest, I'm not sure there's no way to not take ownership of `Config`, but I couldn't find one that I'd be comfortable implementing.

EDIT: Forgot to add reasoning, if for posterity's sake; this change permits users to roll own `tokio` runtimes and spawn `IrcClient`'s futures into them.