### PR TITLE
Make stripping color codes efficiently

### DIFF
--- a/src/proto/colors.rs
+++ b/src/proto/colors.rs
@@ -102,10 +102,10 @@ impl FormattedStringExt for str {
 
 impl FormattedStringExt for String {
     fn is_formatted(&self) -> bool {
-        (&self[..]).is_formatted()
+        self.as_str().is_formatted()
     }
     fn strip_formatting(&self) -> Cow<str> {
-        (&self[..]).strip_formatting()
+        self.as_str().strip_formatting()
     }
 }
 
@@ -116,6 +116,10 @@ mod test {
     #[test]
     fn test_strip_bold() {
         assert_eq!("l\x02ol".strip_formatting(), "lol");
+    }
+    #[test]
+    fn test_strip_bold_from_string() {
+        assert_eq!(String::from("l\x02ol").strip_formatting(), "lol");
     }
 
     #[test]


### PR DESCRIPTION
It also fixes infinite recursion described in https://github.com/aatxe/irc/pull/137#issuecomment-414094604.

Previously, `FormattedStringExt::strip_formatting` always copied whole string even if its return type is `Cow<'_, str>`. Its method signature prevents the impl for `String` to reuse `self` because there is no way to take the ownership from the caller.

For this reason, I have to change the interface of `FormattedStringExt` trait. Theoretically it is backward-incompatible, but I think it's critical only if this trait was implemented in the outside.

Instead the new implementation gains the benefit of memory usages. for `str`, stripping will be almost no-op for unformatted text. And for `String`, it will allocate no additional memory in most of cases.