### PR TITLE
Upgrade native-tls and tokio-tls to 0.2

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -30,7 +30,7 @@ encoding = "0.2"
 failure = "0.1"
 futures = "0.1"
 log = "0.4"
-native-tls = "0.1"
+native-tls = "0.2"
 serde = "1.0"
 serde_derive = "1.0"
 serde_json = { version = "1.0", optional = true }
@@ -40,7 +40,7 @@ tokio-core = "0.1"
 tokio-io = "0.1"
 tokio-mockstream = "1.1"
 tokio-timer = "0.1"
-tokio-tls = "0.1"
+tokio-tls = "0.2"
 toml = { version = "0.4", optional = true }
 
 [dev-dependencies]

--- a/src/client/conn.rs
+++ b/src/client/conn.rs
@@ -6,12 +6,12 @@ use std::io::Read;
 use encoding::EncoderTrap;
 use encoding::label::encoding_from_whatwg_label;
 use futures::{Async, Poll, Future, Sink, StartSend, Stream};
-use native_tls::{Certificate, TlsConnector, Pkcs12};
+use native_tls::{Certificate, TlsConnector, Identity};
 use tokio_codec::Decoder;
 use tokio_core::reactor::Handle;
 use tokio_core::net::{TcpStream, TcpStreamNew};
 use tokio_mockstream::MockStream;
-use tokio_tls::{TlsConnectorExt, TlsStream};
+use tokio_tls::{self, TlsStream};
 
 use error;
 use client::data::Config;
@@ -129,13 +129,13 @@ impl Connection {
         } else if config.use_ssl() {
             let domain = format!("{}", config.server()?);
             info!("Connecting via SSL to {}.", domain);
-            let mut builder = TlsConnector::builder()?;
+            let mut builder = TlsConnector::builder();
             if let Some(cert_path) = config.cert_path() {
                 let mut file = File::open(cert_path)?;
                 let mut cert_data = vec![];
                 file.read_to_end(&mut cert_data)?;
                 let cert = Certificate::from_der(&cert_data)?;
-                builder.add_root_certificate(cert)?;
+                builder.add_root_certificate(cert);
                 info!("Added {} to trusted certificates.", cert_path);
             }
             if let Some(client_cert_path) = config.client_cert_path() {
@@ -143,16 +143,16 @@ impl Connection {
                 let mut file = File::open(client_cert_path)?;
                 let mut client_cert_data = vec![];
                 file.read_to_end(&mut client_cert_data)?;
-                let pkcs12_archive = Pkcs12::from_der(&client_cert_data, &client_cert_pass)?;
-                builder.identity(pkcs12_archive)?;
+                let pkcs12_archive = Identity::from_pkcs12(&client_cert_data, &client_cert_pass)?;
+                builder.identity(pkcs12_archive);
                 info!("Using {} for client certificate authentication.", client_cert_path);
             }
-            let connector = builder.build()?;
+            let connector: tokio_tls::TlsConnector = builder.build()?.into();
             let stream = Box::new(TcpStream::connect(&config.socket_addr()?, handle).map_err(|e| {
                 let res: error::IrcError = e.into();
                 res
             }).and_then(move |socket| {
-                connector.connect_async(&domain, socket).map_err(
+                connector.connect(&domain, socket).map_err(
                     |e| e.into(),
                 )
             }));


### PR DESCRIPTION
This should fix builds for systems with OpenSSL 1.1.1.

[OpenSSL Issue](https://github.com/sfackler/rust-openssl/issues/994)