### PR TITLE
(WIP — do not merge) Switch from native-tls to rustls

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -30,7 +30,6 @@ encoding = "0.2"
 failure = "0.1"
 futures = "0.1"
 log = "0.4"
-native-tls = "0.2"
 serde = "1.0"
 serde_derive = "1.0"
 serde_json = { version = "1.0", optional = true }
@@ -39,9 +38,10 @@ tokio-codec = "0.1"
 tokio-core = "0.1"
 tokio-io = "0.1"
 tokio-mockstream = "1.1"
+tokio-rustls = "0.8.0-alpha"
 tokio-timer = "0.1"
-tokio-tls = "0.2"
 toml = { version = "0.4", optional = true }
+webpki-roots = "0.15.0"
 
 [dev-dependencies]
 args = "2.0"

--- a/src/client/conn.rs
+++ b/src/client/conn.rs
@@ -1,17 +1,14 @@
 //! A module providing IRC connections for use by `IrcServer`s.
-use std::fs::File;
 use std::fmt;
-use std::io::Read;
 
 use encoding::EncoderTrap;
 use encoding::label::encoding_from_whatwg_label;
 use futures::{Async, Poll, Future, Sink, StartSend, Stream};
-use native_tls::{Certificate, TlsConnector, Identity};
 use tokio_codec::Decoder;
 use tokio_core::reactor::Handle;
 use tokio_core::net::{TcpStream, TcpStreamNew};
 use tokio_mockstream::MockStream;
-use tokio_tls::{self, TlsStream};
+use tokio_rustls::{self, TlsStream, rustls, webpki};
 
 use error;
 use client::data::Config;
@@ -23,7 +20,7 @@ pub enum Connection {
     #[doc(hidden)]
     Unsecured(IrcTransport<TcpStream>),
     #[doc(hidden)]
-    Secured(IrcTransport<TlsStream<TcpStream>>),
+    Secured(IrcTransport<RustlsStream>),
     #[doc(hidden)]
     Mock(Logged<MockStream>),
 }
@@ -42,8 +39,11 @@ impl fmt::Debug for Connection {
     }
 }
 
+/// A type alias for the appropriate `tokio_rustls::TlsStream` type.
+type RustlsStream = TlsStream<TcpStream, rustls::ClientSession>;
+
 /// A convenient type alias representing the `TlsStream` future.
-type TlsFuture = Box<Future<Error = error::IrcError, Item = TlsStream<TcpStream>> + Send>;
+type TlsFuture = Box<Future<Error = error::IrcError, Item = RustlsStream> + Send>;
 
 /// A future representing an eventual `Connection`.
 pub enum ConnectionFuture<'a> {
@@ -127,32 +127,17 @@ impl Connection {
         if config.use_mock_connection() {
             Ok(ConnectionFuture::Mock(config))
         } else if config.use_ssl() {
-            let domain = format!("{}", config.server()?);
+            let domain = config.server()?;
             info!("Connecting via SSL to {}.", domain);
-            let mut builder = TlsConnector::builder();
-            if let Some(cert_path) = config.cert_path() {
-                let mut file = File::open(cert_path)?;
-                let mut cert_data = vec![];
-                file.read_to_end(&mut cert_data)?;
-                let cert = Certificate::from_der(&cert_data)?;
-                builder.add_root_certificate(cert);
-                info!("Added {} to trusted certificates.", cert_path);
-            }
-            if let Some(client_cert_path) = config.client_cert_path() {
-                let client_cert_pass = config.client_cert_pass();
-                let mut file = File::open(client_cert_path)?;
-                let mut client_cert_data = vec![];
-                file.read_to_end(&mut client_cert_data)?;
-                let pkcs12_archive = Identity::from_pkcs12(&client_cert_data, &client_cert_pass)?;
-                builder.identity(pkcs12_archive);
-                info!("Using {} for client certificate authentication.", client_cert_path);
-            }
-            let connector: tokio_tls::TlsConnector = builder.build()?.into();
+            let domain = webpki::DNSNameRef::try_from_ascii_str(domain).map_err(|()| {
+                error::IrcError::DomainNameSyntaxError { input: domain.to_owned() }
+            })?.to_owned();
+            let connector: tokio_rustls::TlsConnector = config.rustls_config()?.into();
             let stream = Box::new(TcpStream::connect(&config.socket_addr()?, handle).map_err(|e| {
                 let res: error::IrcError = e.into();
                 res
             }).and_then(move |socket| {
-                connector.connect(&domain, socket).map_err(
+                connector.connect(domain.as_ref(), socket).map_err(
                     |e| e.into(),
                 )
             }));

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -50,7 +50,6 @@ extern crate encoding;
 extern crate futures;
 #[macro_use]
 extern crate log;
-extern crate native_tls;
 extern crate serde;
 #[macro_use]
 extern crate serde_derive;
@@ -62,10 +61,11 @@ extern crate tokio_codec;
 extern crate tokio_core;
 extern crate tokio_io;
 extern crate tokio_mockstream;
+extern crate tokio_rustls;
 extern crate tokio_timer;
-extern crate tokio_tls;
 #[cfg(feature = "toml")]
 extern crate toml;
+extern crate webpki_roots;
 
 pub mod client;
 pub mod error;


### PR DESCRIPTION
This is an unfinished patch to switch `irc` from depending on [`tokio-tls`] and [`native-tls`], which @aatxe says "has caused a reasonable amount of annoyance", to [`tokio-rustls`] and (through it) [`rustls`].

This patch uses the 0.8.0-alpha version of `tokio-rustls`, which has a `tokio-tls`-esque API. Even if this patch were finished, it should not be applied until that `tokio-rustls` API fully is released.

While `irc` compiles with this patch applied, the following work remains to be done:

- Implement CertFP — `rustls` provides a less convenient API for client certificate authentication than does `native-tls`, and I (@8573) don't understand cryptographic APIs well enough to implement CertFP with it. This WIP version of my patch provides only a stub implementation of the necessary `rustls` trait, [`ResolvesClientCert`], which implementation will not actually provide any client certificate to `rustls`, even if one is specified in the `irc`-level client `Config`.

- Run `irc`'s test suite with this patch applied.

- Confirm that `irc`'s dependents still work with this patch applied.

[`ResolvesClientCert`]: <https://docs.rs/rustls/0.13.1/rustls/trait.ResolvesClientCert.html>
[`native-tls`]: <https://crates.io/crates/native-tls>
[`rustls`]: <https://crates.io/crates/rustls>
[`tokio-rustls`]: <https://crates.io/crates/tokio-rustls>
[`tokio-tls`]: <https://crates.io/crates/tokio-tls>

