### PR TITLE
Refactor IrcClientFuture and ConnectionFuture to own the config

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,7 +70,7 @@ fn main() {
     };
 
     let mut reactor = IrcReactor::new().unwrap();
-    let client = reactor.prepare_client_and_connect(&config).unwrap();
+    let client = reactor.prepare_client_and_connect(config).unwrap();
     client.identify().unwrap();
 
     reactor.register_client_with_handler(client, |client, message| {

--- a/examples/multiserver.rs
+++ b/examples/multiserver.rs
@@ -26,7 +26,7 @@ fn main() {
     for config in configs {
         // Immediate errors like failure to resolve the server's domain or to establish any connection will
         // manifest here in the result of prepare_client_and_connect.
-        let client = reactor.prepare_client_and_connect(&config).unwrap();
+        let client = reactor.prepare_client_and_connect(config).unwrap();
         client.identify().unwrap();
         // Here, we tell the reactor to setup this client for future handling (in run) using the specified
         // handler function process_msg.

--- a/examples/reactor.rs
+++ b/examples/reactor.rs
@@ -14,7 +14,7 @@ fn main() {
     };
 
     let mut reactor = IrcReactor::new().unwrap();
-    let client = reactor.prepare_client_and_connect(&config).unwrap();
+    let client = reactor.prepare_client_and_connect(config).unwrap();
     client.identify().unwrap();
 
     reactor.register_client_with_handler(client, |client, message| {

--- a/examples/reconnector.rs
+++ b/examples/reconnector.rs
@@ -26,7 +26,7 @@ fn main() {
     loop {
         let res = configs.iter().fold(Ok(()), |acc, config| {
             acc.and(
-                reactor.prepare_client_and_connect(&config).and_then(|client| {
+                reactor.prepare_client_and_connect(config.clone()).and_then(|client| {
                     client.identify().and(Ok(client))
                 }).and_then(|client| {
                     reactor.register_client_with_handler(client, process_msg);

--- a/examples/tooter.rs
+++ b/examples/tooter.rs
@@ -18,7 +18,7 @@ fn main() {
     // We need to create a reactor first and foremost
     let mut reactor = IrcReactor::new().unwrap();
     // and then create a client via its API.
-    let client = reactor.prepare_client_and_connect(&config).unwrap();
+    let client = reactor.prepare_client_and_connect(config).unwrap();
     // Then, we identify
     client.identify().unwrap();
     // and clone just as before.

--- a/src/client/conn.rs
+++ b/src/client/conn.rs
@@ -8,7 +8,8 @@ use encoding::label::encoding_from_whatwg_label;
 use futures::{Async, Poll, Future, Sink, StartSend, Stream};
 use native_tls::{Certificate, TlsConnector, Identity};
 use tokio_codec::Decoder;
-use tokio::net::{TcpStream, ConnectFuture};
+use tokio::net::{TcpStream};
+use tokio::net::tcp::ConnectFuture;
 use tokio_mockstream::MockStream;
 use tokio_tls::{self, TlsStream};
 

--- a/src/client/reactor.rs
+++ b/src/client/reactor.rs
@@ -16,7 +16,7 @@
 //! fn main() {
 //!   let config = Config::default();
 //!   let mut reactor = IrcReactor::new().unwrap();
-//!   let client = reactor.prepare_client_and_connect(&config).unwrap();
+//!   let client = reactor.prepare_client_and_connect(config).unwrap();
 //!   reactor.register_client_with_handler(client, process_msg);
 //!   reactor.run().unwrap();
 //! }
@@ -63,13 +63,12 @@ impl IrcReactor {
     /// # use std::default::Default;
     /// # use irc::client::prelude::*;
     /// # fn main() {
-    /// # let config = Config::default();
     /// let future_client = IrcReactor::new().and_then(|mut reactor| {
-    ///     reactor.prepare_client(&config)
+    ///     reactor.prepare_client(Config::default())
     /// });
     /// # }
     /// ```
-    pub fn prepare_client<'a>(&mut self, config: &'a Config) -> error::Result<IrcClientFuture<'a>> {
+    pub fn prepare_client(&mut self, config: Config) -> error::Result<IrcClientFuture> {
         IrcClient::new_future(config)
     }
 
@@ -82,9 +81,8 @@ impl IrcReactor {
     /// # use std::default::Default;
     /// # use irc::client::prelude::*;
     /// # fn main() {
-    /// # let config = Config::default();
     /// let client = IrcReactor::new().and_then(|mut reactor| {
-    ///     reactor.prepare_client(&config).and_then(|future| {
+    ///     reactor.prepare_client(Config::default()).and_then(|future| {
     ///         reactor.connect_client(future)
     ///     })
     /// });
@@ -107,13 +105,12 @@ impl IrcReactor {
     /// # use std::default::Default;
     /// # use irc::client::prelude::*;
     /// # fn main() {
-    /// # let config = Config::default();
     /// let client = IrcReactor::new().and_then(|mut reactor| {
-    ///     reactor.prepare_client_and_connect(&config)
+    ///     reactor.prepare_client_and_connect(Config::default())
     /// });
     /// # }
     /// ```
-    pub fn prepare_client_and_connect(&mut self, config: &Config) -> error::Result<IrcClient> {
+    pub fn prepare_client_and_connect(&mut self, config: Config) -> error::Result<IrcClient> {
         self.prepare_client(config).and_then(|future| self.connect_client(future))
     }
 
@@ -130,7 +127,7 @@ impl IrcReactor {
     /// # fn main() {
     /// # let config = Config::default();
     /// let mut reactor = IrcReactor::new().unwrap();
-    /// let client = reactor.prepare_client_and_connect(&config).unwrap();
+    /// let client = reactor.prepare_client_and_connect(config).unwrap();
     /// reactor.register_client_with_handler(client, |client, msg| {
     ///   // Message processing happens here.
     ///   Ok(())
@@ -176,7 +173,7 @@ impl IrcReactor {
     /// # fn main() {
     /// # let config = Config::default();
     /// let mut reactor = IrcReactor::new().unwrap();
-    /// let client = reactor.prepare_client_and_connect(&config).unwrap();
+    /// let client = reactor.prepare_client_and_connect(config).unwrap();
     /// reactor.register_client_with_handler(client, process_msg);
     /// reactor.run().unwrap();
     /// # }


### PR DESCRIPTION
This refactors IrcClientFuture and ConnectionFuture to own
the config instead of holding a reference.

This is unfortunately a breaking change. 
I didn't see a way to keep the old public API without the reference.

This is required though for dynamically connecting to additional servers on the same reactor.

The `examples/multiserver.rs` example only works because the `Config` structs are in the same scope that `Reactor::run()` is called, which is not possible in a dynamic (future) context, where you need to use `Handle::spawn` to initiate a new client.