### PR TITLE
Add test bot for CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,6 +9,7 @@ script:
   - cargo test --verbose --features "toml yaml"
   - cargo test --doc
   - cargo test --verbose --no-default-features
+  - cargo run --bin build-bot
 notifications:
   email: false
   irc:

--- a/src/bin/build-bot.rs
+++ b/src/bin/build-bot.rs
@@ -27,8 +27,11 @@ fn main() {
                 client.send_privmsg(
                     "#commits",
                     format!(
-                        "Hello from Travis CI! {}/{} {}: {}",
-                        repository_slug, branch, commit, commit_message
+                        "[{}/{}] ({}) {}",
+                        repository_slug,
+                        branch,
+                        &commit[..7],
+                        commit_message
                     ),
                 )?;
                 client.send_quit("QUIT")?;

--- a/src/bin/build-bot.rs
+++ b/src/bin/build-bot.rs
@@ -1,0 +1,43 @@
+extern crate irc;
+
+use irc::client::prelude::*;
+use std::default::Default;
+use std::env;
+
+fn main() {
+    let repository_slug = env::var("TRAVIS_REPO_SLUG").unwrap();
+    let branch = env::var("TRAVIS_BRANCH").unwrap();
+    let commit = env::var("TRAVIS_COMMIT").unwrap();
+    let commit_message = env::var("TRAVIS_COMMIT_MESSAGE").unwrap();
+
+    let config = Config {
+        nickname: Some("irc-crate-ci".to_owned()),
+        server: Some("irc.pdgn.co".to_owned()),
+        use_ssl: Some(true),
+        ..Default::default()
+    };
+
+    let mut reactor = IrcReactor::new().unwrap();
+    let client = reactor.prepare_client_and_connect(&config).unwrap();
+    client.identify().unwrap();
+
+    reactor.register_client_with_handler(client, move |client, message| {
+        match message.command {
+            Command::Response(Response::RPL_ISUPPORT, _, _) => {
+                client.send_privmsg(
+                    "#commits",
+                    format!(
+                        "Hello from Travis CI! {}/{} {}: {}",
+                        repository_slug, branch, commit, commit_message
+                    ),
+                )?;
+                client.send_quit("QUIT")?;
+            }
+            _ => (),
+        };
+
+        Ok(())
+    });
+
+    reactor.run().unwrap();
+}


### PR DESCRIPTION
Fixes #142 

@aatxe I have put this in `src/bin` as I wasn't too sure on the best way to approach this. Obviously the bot doesn't want to be part of the normal tests as it should only run during a CI build, that seems to leave `src/examples` and `src/bin` as the two possible places to put this. 

Out of the two the bin folder seemed most appropriate as it separates this out from the examples and allows us to run the bot as an individual component during the CI process.

I would really appreciate any feedback on this as I am pretty new to Rust 🙂🦀