### PR TITLE
Discussion: Make 'client' an optional feature?

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,7 +16,10 @@ is-it-maintained-issue-resolution = { repository = "aatxe/irc" }
 is-it-maintained-open-issues = { repository = "aatxe/irc" }
 
 [features]
-default = ["ctcp", "toml"]
+default = ["client", "ctcp", "toml"]
+client = ["tokio-codec", "tokio-core", "tokio-io",
+    "tokio-mockstream", "tokio-timer", "tokio-tls",
+    "futures", "native-tls"]
 ctcp = []
 nochanlists = []
 json = ["serde_json"]
@@ -28,19 +31,19 @@ bytes = "0.4"
 chrono = "0.4"
 encoding = "0.2"
 failure = "0.1"
-futures = "0.1"
+futures = { version = "0.1", optional = true }
 log = "0.4"
-native-tls = "0.2"
+native-tls = { version = "0.2", optional = true }
 serde = "1.0"
 serde_derive = "1.0"
 serde_json = { version = "1.0", optional = true }
 serde_yaml = { version = "0.7", optional = true }
-tokio-codec = "0.1"
-tokio-core = "0.1"
-tokio-io = "0.1"
-tokio-mockstream = "1.1"
-tokio-timer = "0.1"
-tokio-tls = "0.2"
+tokio-codec = { version = "0.1", optional = true }
+tokio-core = { version = "0.1", optional = true }
+tokio-io = { version = "0.1", optional = true }
+tokio-mockstream = { version = "1.1", optional = true }
+tokio-timer = { version = "0.1", optional = true }
+tokio-tls = { version = "0.2", optional = true }
 toml = { version = "0.4", optional = true }
 
 [dev-dependencies]

--- a/examples/convertconf.rs
+++ b/examples/convertconf.rs
@@ -7,11 +7,13 @@ use std::process::exit;
 
 use args::{Args, ArgsError};
 use getopts::Occur;
+#[cfg(feature = "client")]
 use irc::client::data::Config;
 
 const PROGRAM_DESC: &str = "Use this program to convert configs between {JSON, TOML, YAML}.";
 const PROGRAM_NAME: &str = "convertconf";
 
+#[cfg(feature = "client")]
 fn main() {
     let args: Vec<_> = env::args().collect();
     match parse(&args) {
@@ -59,4 +61,9 @@ fn parse(input: &[String]) -> Result<Option<(String, String)>, ArgsError> {
         args.value_of("input")?,
         args.value_of("output")?,
     )))
+}
+
+#[cfg(not(feature = "client"))]
+fn main() {
+    eprintln!("built without client support")
 }

--- a/examples/multiserver.rs
+++ b/examples/multiserver.rs
@@ -2,8 +2,10 @@ extern crate irc;
 
 use std::default::Default;
 use irc::error;
+#[cfg(feature = "client")]
 use irc::client::prelude::*;
 
+#[cfg(feature = "client")]
 fn main() {
     let cfg1 = Config {
         nickname: Some("pickles".to_owned()),
@@ -37,6 +39,7 @@ fn main() {
     reactor.run().unwrap();
 }
 
+#[cfg(feature = "client")]
 fn process_msg(client: &IrcClient, message: Message) -> error::Result<()> {
     print!("{}", message);
     match message.command {
@@ -48,4 +51,9 @@ fn process_msg(client: &IrcClient, message: Message) -> error::Result<()> {
         _ => (),
     }
     Ok(())
+}
+
+#[cfg(not(feature = "client"))]
+fn main() {
+    eprintln!("built without client support")
 }

--- a/examples/reactor.rs
+++ b/examples/reactor.rs
@@ -1,10 +1,11 @@
 extern crate irc;
 
-use std::default::Default;
-use irc::client::prelude::*;
-
 // This example is meant to be a direct analogue to simple.rs using the reactor API.
+#[cfg(feature = "client")]
 fn main() {
+    use std::default::Default;
+    use irc::client::prelude::*;
+
     let config = Config {
         nickname: Some("pickles".to_owned()),
         alt_nicks: Some(vec!["bananas".to_owned(), "apples".to_owned()]),
@@ -28,4 +29,9 @@ fn main() {
     });
 
     reactor.run().unwrap();
+}
+
+#[cfg(not(feature = "client"))]
+fn main() {
+    eprintln!("built without client support")
 }

--- a/examples/reconnector.rs
+++ b/examples/reconnector.rs
@@ -2,8 +2,10 @@ extern crate irc;
 
 use std::default::Default;
 use irc::error;
+#[cfg(feature = "client")]
 use irc::client::prelude::*;
 
+#[cfg(feature = "client")]
 fn main() {
     let cfg1 = Config {
         nickname: Some("pickles".to_owned()),
@@ -44,6 +46,7 @@ fn main() {
     }
 }
 
+#[cfg(feature = "client")]
 fn process_msg(client: &IrcClient, message: Message) -> error::Result<()> {
     print!("{}", message);
     if let Command::PRIVMSG(ref target, ref msg) = message.command {
@@ -54,4 +57,9 @@ fn process_msg(client: &IrcClient, message: Message) -> error::Result<()> {
         }
     }
     Ok(())
+}
+
+#[cfg(not(feature = "client"))]
+fn main() {
+    eprintln!("built without client support")
 }

--- a/examples/repeater.rs
+++ b/examples/repeater.rs
@@ -1,8 +1,10 @@
 extern crate irc;
 
 use std::default::Default;
+#[cfg(feature = "client")]
 use irc::client::prelude::*;
 
+#[cfg(feature = "client")]
 fn main() {
     let config = Config {
         nickname: Some("repeater".to_owned()),
@@ -37,4 +39,9 @@ fn main() {
             }
         }
     }).unwrap()
+}
+
+#[cfg(not(feature = "client"))]
+fn main() {
+    eprintln!("built without client support")
 }

--- a/examples/simple.rs
+++ b/examples/simple.rs
@@ -1,9 +1,10 @@
 extern crate irc;
 
-use std::default::Default;
-use irc::client::prelude::*;
-
+#[cfg(feature = "client")]
 fn main() {
+    use std::default::Default;
+    use irc::client::prelude::*;
+
     let config = Config {
         nickname: Some("pickles".to_owned()),
         alt_nicks: Some(vec!["bananas".to_owned(), "apples".to_owned()]),
@@ -23,4 +24,9 @@ fn main() {
             }
         }
     }).unwrap();
+}
+
+#[cfg(not(feature = "client"))]
+fn main() {
+    eprintln!("built without client support")
 }

--- a/examples/simple_ssl.rs
+++ b/examples/simple_ssl.rs
@@ -1,8 +1,10 @@
 extern crate irc;
 
 use std::default::Default;
+#[cfg(feature = "client")]
 use irc::client::prelude::*;
 
+#[cfg(feature = "client")]
 fn main() {
     let config = Config {
         nickname: Some("pickles".to_owned()),
@@ -23,4 +25,9 @@ fn main() {
             }
         }
     }).unwrap();
+}
+
+#[cfg(not(feature = "client"))]
+fn main() {
+    eprintln!("built without client support")
 }

--- a/examples/tooter.rs
+++ b/examples/tooter.rs
@@ -1,13 +1,15 @@
 extern crate irc;
+#[cfg(feature = "client")]
 extern crate tokio_timer;
 
-use std::default::Default;
-use std::time::Duration;
-use irc::client::prelude::*;
-use irc::error::IrcError;
-
 // NOTE: this example is a conversion of `tweeter.rs` to an asynchronous style with `IrcReactor`.
+#[cfg(feature = "client")]
 fn main() {
+    use std::default::Default;
+    use std::time::Duration;
+    use irc::client::prelude::*;
+    use irc::error::IrcError;
+
     let config = Config {
         nickname: Some("mastodon".to_owned()),
         server: Some("irc.mozilla.org".to_owned()),
@@ -48,4 +50,9 @@ fn main() {
 
     // Then, on the main thread, we finally run the reactor which blocks the program indefinitely.
     reactor.run().unwrap();
+}
+
+#[cfg(not(feature = "client"))]
+fn main() {
+    eprintln!("built without client support")
 }

--- a/examples/tweeter.rs
+++ b/examples/tweeter.rs
@@ -1,12 +1,13 @@
 extern crate irc;
 
-use std::default::Default;
-use std::thread;
-use std::time::Duration;
-use irc::client::prelude::*;
-
 // NOTE: you can find an asynchronous version of this example with `IrcReactor` in `tooter.rs`.
+#[cfg(feature = "client")]
 fn main() {
+    use std::default::Default;
+    use std::thread;
+    use std::time::Duration;
+    use irc::client::prelude::*;
+
     let config = Config {
         nickname: Some("pickles".to_owned()),
         server: Some("irc.mozilla.org".to_owned()),
@@ -24,4 +25,9 @@ fn main() {
         client.send_privmsg("#rust-spam", "TWEET TWEET").unwrap();
         thread::sleep(Duration::new(10, 0));
     }
+}
+
+#[cfg(not(feature = "client"))]
+fn main() {
+    eprintln!("built without client support")
 }

--- a/src/bin/build-bot.rs
+++ b/src/bin/build-bot.rs
@@ -1,9 +1,13 @@
 extern crate irc;
 
+#[cfg(feature = "client")]
 use irc::client::prelude::*;
+#[cfg(feature = "client")]
 use std::default::Default;
+#[cfg(feature = "client")]
 use std::env;
 
+#[cfg(feature = "client")]
 fn main() {
     let repository_slug = env::var("TRAVIS_REPO_SLUG").unwrap();
     let branch = env::var("TRAVIS_BRANCH").unwrap();
@@ -43,4 +47,9 @@ fn main() {
     });
 
     reactor.run().unwrap();
+}
+
+#[cfg(not(feature = "client"))]
+fn main() {
+    eprintln!("built without client support")
 }

--- a/src/error.rs
+++ b/src/error.rs
@@ -4,13 +4,17 @@ use std::io::Error as IoError;
 use std::sync::mpsc::RecvError;
 
 use failure;
+#[cfg(feature = "client")]
 use futures::sync::mpsc::SendError;
+#[cfg(feature = "client")]
 use futures::sync::oneshot::Canceled;
+#[cfg(feature = "client")]
 use native_tls::Error as TlsError;
 #[cfg(feature = "json")]
 use serde_json::Error as JsonError;
 #[cfg(feature = "yaml")]
 use serde_yaml::Error as YamlError;
+#[cfg(feature = "client")]
 use tokio_timer::TimerError;
 #[cfg(feature = "toml")]
 use toml::de::Error as TomlReadError;
@@ -31,23 +35,45 @@ pub enum IrcError {
 
     /// An internal TLS error.
     #[fail(display = "a TLS error occurred")]
+    #[cfg(feature = "client")]
     Tls(#[cause] TlsError),
+
+    /// An internal TLS error.
+    #[cfg(not(feature = "client"))]
+    #[fail(display = "a TLS error occurred")]
+    Tls(()),
 
     /// An internal synchronous channel closed.
     #[fail(display = "a sync channel closed")]
     SyncChannelClosed(#[cause] RecvError),
 
     /// An internal asynchronous channel closed.
+    #[cfg(feature = "client")]
     #[fail(display = "an async channel closed")]
     AsyncChannelClosed(#[cause] SendError<Message>),
 
+    #[cfg(not(feature = "client"))]
+    #[fail(display = "an async channel closed")]
+    AsyncChannelClosed(()),
+
     /// An internal oneshot channel closed.
+    #[cfg(feature = "client")]
     #[fail(display = "a oneshot channel closed")]
     OneShotCanceled(#[cause] Canceled),
 
+    /// An internal oneshot channel closed.
+    #[cfg(not(feature = "client"))]
+    #[fail(display = "a oneshot channel closed")]
+    OneShotCanceled(()),
+
     /// An internal timer error.
+    #[cfg(feature = "client")]
     #[fail(display = "timer failed")]
     Timer(#[cause] TimerError),
+
+    #[cfg(not(feature = "client"))]
+    #[fail(display = "timer failed")]
+    Timer(()),
 
     /// Error for invalid configurations.
     #[fail(display = "invalid config: {}", path)]
@@ -216,30 +242,35 @@ impl From<IoError> for IrcError {
     }
 }
 
+#[cfg(feature = "client")]
 impl From<TlsError> for IrcError {
     fn from(e: TlsError) -> IrcError {
         IrcError::Tls(e)
     }
 }
 
+#[cfg(feature = "client")]
 impl From<RecvError> for IrcError {
     fn from(e: RecvError) -> IrcError {
         IrcError::SyncChannelClosed(e)
     }
 }
 
+#[cfg(feature = "client")]
 impl From<SendError<Message>> for IrcError {
     fn from(e: SendError<Message>) -> IrcError {
         IrcError::AsyncChannelClosed(e)
     }
 }
 
+#[cfg(feature = "client")]
 impl From<Canceled> for IrcError {
     fn from(e: Canceled) -> IrcError {
         IrcError::OneShotCanceled(e)
     }
 }
 
+#[cfg(feature = "client")]
 impl From<TimerError> for IrcError {
     fn from(e: TimerError) -> IrcError {
         IrcError::Timer(e)

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -18,8 +18,10 @@
 //!
 //! ```no_run
 //! # extern crate irc;
+//! # #[cfg(feature = "client")]
 //! use irc::client::prelude::*;
 //!
+//! # #[cfg(feature = "client")]
 //! # fn main() {
 //! // configuration is loaded from config.toml into a Config
 //! let client = IrcClient::new("config.toml").unwrap();
@@ -36,6 +38,7 @@
 //!     }
 //! }).unwrap();
 //! # }
+//! # #[cfg(not(feature = "client"))] fn main() {}
 //! ```
 
 #![warn(missing_docs)]
@@ -47,9 +50,11 @@ extern crate chrono;
 extern crate failure;
 extern crate encoding;
 #[macro_use]
+#[cfg(feature = "client")]
 extern crate futures;
 #[macro_use]
 extern crate log;
+#[cfg(feature = "client")]
 extern crate native_tls;
 extern crate serde;
 #[macro_use]
@@ -58,19 +63,27 @@ extern crate serde_derive;
 extern crate serde_json;
 #[cfg(feature = "yaml")]
 extern crate serde_yaml;
+#[cfg(feature = "client")]
 extern crate tokio_codec;
+#[cfg(feature = "client")]
 extern crate tokio_core;
+#[cfg(feature = "client")]
 extern crate tokio_io;
+#[cfg(feature = "client")]
 extern crate tokio_mockstream;
+#[cfg(feature = "client")]
 extern crate tokio_timer;
+#[cfg(feature = "client")]
 extern crate tokio_tls;
 #[cfg(feature = "toml")]
 extern crate toml;
 
+#[cfg(feature = "client")]
 pub mod client;
 pub mod error;
 pub mod proto;
 
+#[cfg(feature = "client")]
 const VERSION_STR: &str = concat!(
     env!("CARGO_PKG_NAME"),
     ":",

--- a/src/proto/message.rs
+++ b/src/proto/message.rs
@@ -31,7 +31,7 @@ impl Message {
     /// # Example
     /// ```
     /// # extern crate irc;
-    /// # use irc::client::prelude::*;
+    /// # use irc::proto::Message;
     /// # fn main() {
     /// let message = Message::new(
     ///     Some("nickname!username@hostname"), "JOIN", vec!["#channel"], None
@@ -69,7 +69,7 @@ impl Message {
     /// # Example
     /// ```
     /// # extern crate irc;
-    /// # use irc::client::prelude::*;
+    /// # use irc::proto::Message;
     /// # fn main() {
     /// let message = Message::new(
     ///     Some("nickname!username@hostname"), "JOIN", vec!["#channel"], None
@@ -99,7 +99,7 @@ impl Message {
     /// # Example
     /// ```
     /// # extern crate irc;
-    /// # use irc::client::prelude::*;
+    /// # use irc::proto::Message;
     /// # fn main() {
     /// let msg1 = Message::new(
     ///     Some("ada"), "PRIVMSG", vec!["#channel"], Some("Hi, everyone!")
@@ -124,7 +124,7 @@ impl Message {
     /// # Example
     /// ```
     /// # extern crate irc;
-    /// # use irc::client::prelude::*;
+    /// # use irc::proto::Message;
     /// # fn main() {
     /// let msg = Message::new(
     ///     Some("ada"), "PRIVMSG", vec!["#channel"], Some("Hi, everyone!")

--- a/src/proto/mod.rs
+++ b/src/proto/mod.rs
@@ -4,7 +4,9 @@ pub mod caps;
 pub mod chan;
 pub mod command;
 pub mod colors;
+#[cfg(feature = "client")]
 pub mod irc;
+#[cfg(feature = "client")]
 pub mod line;
 pub mod message;
 pub mod mode;
@@ -14,6 +16,7 @@ pub use self::caps::{Capability, NegotiationVersion};
 pub use self::chan::ChannelExt;
 pub use self::colors::FormattedStringExt;
 pub use self::command::{BatchSubCommand, CapSubCommand, Command};
+#[cfg(feature = "client")]
 pub use self::irc::IrcCodec;
 pub use self::message::Message;
 pub use self::mode::{ChannelMode, Mode, UserMode};


### PR DESCRIPTION
This PR enables using just the `irc::proto` part of the crate, without building the `irc::client` part.

This allows dropping >70% of the deps, including `native-tls` which fails horribly to build on anything fun.

The changes are noisy, but there are zero logic changes:

 * conditional use of the entire client module
 * conditional use of any imported library
 * stub implementation of errors, examples and doctests, with `()` payloads or just that print "nah".

`.travis.yml` is already configured to check `--no-default-features`, and it passes.

I did not make the code warning-clean with `test --no-default-features`, this would (simply!) involve adding more `cfg(` everywhere. In my opinion, it is unlikely that it would be possible to move more stuff into the "client" module, to reduce the size of this change. Perhaps the lineproto stuff? Not super relevant.

(I'm writing a server-like-thing, if that wasn't obvious.)

Are you willing to carry this feature?