### PR TITLE
Don't send an empty CTCP SOURCE response

### DIFF
--- a/src/client/mod.rs
+++ b/src/client/mod.rs
@@ -550,8 +550,7 @@ impl ClientState {
             self.send_ctcp_internal(
                 resp,
                 &format!("SOURCE {}", self.config().source()),
-            )?;
-            self.send_ctcp_internal(resp, "SOURCE")
+            )
         } else if tokens[0].eq_ignore_ascii_case("PING") && tokens.len() > 1 {
             self.send_ctcp_internal(resp, &format!("PING {}", tokens[1]))
         } else if tokens[0].eq_ignore_ascii_case("TIME") {

--- a/src/client/mod.rs
+++ b/src/client/mod.rs
@@ -1298,8 +1298,7 @@ mod test {
         }).unwrap();
         assert_eq!(
             &get_client_value(client)[..],
-            "NOTICE test :\u{001}SOURCE https://github.com/aatxe/irc\u{001}\r\n\
-             NOTICE test :\u{001}SOURCE\u{001}\r\n"
+            "NOTICE test :\u{001}SOURCE https://github.com/aatxe/irc\u{001}\r\n"
         );
     }
 


### PR DESCRIPTION
Noticed this while asking a url-bot-rs instance for it's `SOURCE`.

```
-- CTCP query to u: SOURCE
-- CTCP reply from u: SOURCE https://github.com/nuxeh/url-bot-rs
-- CTCP reply from u: SOURCE
```