### PR TITLE
Fix compilation errors on 0.14

### DIFF
--- a/irc-proto/src/command.rs
+++ b/irc-proto/src/command.rs
@@ -1787,7 +1787,7 @@ impl FromStr for BatchSubCommand {
 
 #[cfg(test)]
 mod test {
-    use proto::Message;
+    use crate::Message;
     use super::Response;
     use super::Command;
 

--- a/src/bin/build-bot.rs
+++ b/src/bin/build-bot.rs
@@ -18,7 +18,7 @@ fn main() {
     };
 
     let mut reactor = IrcReactor::new().unwrap();
-    let client = reactor.prepare_client_and_connect(&config).unwrap();
+    let client = reactor.prepare_client_and_connect(config).unwrap();
     client.identify().unwrap();
 
     reactor.register_client_with_handler(client, move |client, message| {

--- a/src/client/reactor.rs
+++ b/src/client/reactor.rs
@@ -137,10 +137,11 @@ impl IrcReactor {
     pub fn register_client_with_handler<F, U>(
         &mut self, client: IrcClient, mut handler: F
     ) where F: FnMut(&IrcClient, Message) -> U + 'static,
-            U: IntoFuture<Item = (), Error = error::IrcError> + 'static {
+            U: IntoFuture<Item = (), Error = error::IrcError> + 'static,
+            U::Future: Send {
         let handle = self.inner.handle().clone();
         self.handlers.push(Box::new(client.stream().for_each(move |message| {
-            handle.spawn(handler(&client, message).into_future().map_err(|_| (())));
+            handle.spawn(handler(&client, message).into_future().map_err(|_| (())))?;
 
             Ok(())
         })));

--- a/src/error.rs
+++ b/src/error.rs
@@ -11,6 +11,7 @@ use native_tls::Error as TlsError;
 use serde_json::Error as JsonError;
 #[cfg(feature = "yaml")]
 use serde_yaml::Error as YamlError;
+use tokio::executor::SpawnError;
 use tokio_timer::TimerError;
 #[cfg(feature = "toml")]
 use toml::de::Error as TomlReadError;
@@ -33,6 +34,10 @@ pub enum IrcError {
     /// An internal TLS error.
     #[fail(display = "a TLS error occurred")]
     Tls(#[cause] TlsError),
+
+    /// An error caused by Tokio being unable to spawn a task.
+    #[fail(display = "unable to spawn task")]
+    Spawn(#[cause] SpawnError),
 
     /// An internal synchronous channel closed.
     #[fail(display = "a sync channel closed")]
@@ -185,6 +190,12 @@ impl From<IoError> for IrcError {
 impl From<TlsError> for IrcError {
     fn from(e: TlsError) -> IrcError {
         IrcError::Tls(e)
+    }
+}
+
+impl From<SpawnError> for IrcError {
+    fn from(e: SpawnError) -> IrcError {
+        IrcError::Spawn(e)
     }
 }
 


### PR DESCRIPTION
- Type can not be safely sent across threads (src/client/reactor.rs:141)
- Unhandled Result  (src/client/reactor.rs:144)
- Expected value, found reference (src/bin/build-bot.rs:21)