### PR TITLE
Upgrade bytes to match irc-proto

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -29,7 +29,7 @@ yaml = ["serde_yaml"]
 [dependencies]
 thiserror = "1.0.2"
 bufstream = "0.1"
-bytes = "0.4"
+bytes = "0.5"
 chrono = "0.4"
 encoding = "0.2"
 irc-proto = { version = "*", path = "irc-proto" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -41,10 +41,10 @@ tokio = { version = "0.2.4", features = ["time", "net", "stream", "macros", "str
 tokio-util = { version = "0.2.0", features = ["codec"] }
 tokio-tls = "0.3.0"
 serde_json = { version = "1.0", optional = true }
-serde_yaml = { version = "0.7", optional = true }
-toml = { version = "0.4", optional = true }
+serde_yaml = { version = "0.8", optional = true }
+toml = { version = "0.5", optional = true }
 pin-utils = "0.1.0-alpha.4"
-parking_lot = "0.9.0"
+parking_lot = "0.10.0"
 futures-channel = "0.3.1"
 futures-util = { version = "0.3.1", features = ["sink"] }
 
@@ -53,4 +53,4 @@ futures = "0.3.1"
 anyhow = "1.0.13"
 args = "2.0"
 getopts = "0.2"
-env_logger = "0.6.2"
+env_logger = "0.7"


### PR DESCRIPTION
This means there's no more bytes mis-match between irc and irc-proto/tokio. I'm looking into other packages as well.