### PR TITLE
Handle suffix as a plain param

### DIFF
--- a/examples/build-bot.rs
+++ b/examples/build-bot.rs
@@ -27,7 +27,7 @@ async fn main() -> irc::error::Result<()> {
 
     while let Some(message) = stream.next().await.transpose()? {
         match message.command {
-            Command::Response(Response::RPL_ISUPPORT, _, _) => {
+            Command::Response(Response::RPL_ISUPPORT, _) => {
                 client.send_privmsg(
                     "#commits",
                     format!(


### PR DESCRIPTION
This replaces the internal handling of suffix and treats it as "just another param". Thankfully, this lets us clean up command parsing because we don't need to handle suffix vs params separately for every single command.