### PR TITLE
Bump tokio-rustls, tokio-socks, webpki-roots, parking_lot

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -49,7 +49,7 @@ futures-channel = "0.3.0"
 futures-util = { version = "0.3.0", features = ["sink"] }
 irc-proto = { version = "0.14.0", path = "irc-proto" }
 log = "0.4.0"
-parking_lot = "0.10.0"
+parking_lot = "0.11.0"
 pin-utils = "0.1.0-alpha.4"
 thiserror = "1.0.0"
 tokio = { version = "0.2.0", features = ["macros", "net", "stream", "time"] }
@@ -63,13 +63,13 @@ serde_yaml = { version = "0.8.0", optional = true }
 toml = { version = "0.5.0", optional = true }
 
 # Feature - Proxy
-tokio-socks = { version = "0.2.0", optional = true }
+tokio-socks = { version = "0.3.0", optional = true }
 
 # Feature - TLS
 native-tls = { version = "0.2.0", optional = true }
-tokio-rustls = { version = "0.13.0", optional = true }
+tokio-rustls = { version = "0.14.0", optional = true }
 tokio-tls = { version = "0.3.0", optional = true }
-webpki-roots = { version = "0.19.0", optional = true }
+webpki-roots = { version = "0.20.0", optional = true }
 
 
 [dev-dependencies]


### PR DESCRIPTION
Subj (all of these are backward compatible for irc)