### PR TITLE
Remove unused dependencies

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -41,8 +41,6 @@ tls-rust = ["tokio-rustls", "webpki-roots"]
 
 
 [dependencies]
-bufstream = "0.1.0"
-bytes = "0.5.0"
 chrono = "0.4.0"
 encoding = "0.2.0"
 futures-channel = "0.3.0"
@@ -50,7 +48,6 @@ futures-util = { version = "0.3.0", features = ["sink"] }
 irc-proto = { version = "0.14.0", path = "irc-proto" }
 log = "0.4.0"
 parking_lot = "0.11.0"
-pin-utils = "0.1.0-alpha.4"
 thiserror = "1.0.0"
 tokio = { version = "0.2.0", features = ["macros", "net", "stream", "time"] }
 tokio-util = { version = "0.3.0", features = ["codec"] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -72,7 +72,7 @@ webpki-roots = { version = "0.20.0", optional = true }
 [dev-dependencies]
 anyhow = "1.0.0"
 args = "2.0.0"
-env_logger = "0.7.0"
+env_logger = "0.8.0"
 futures = "0.3.0"
 getopts = "0.2.0"
 


### PR DESCRIPTION
Hi o/

This PR remove unused dependencies for the irc crate (none was unused for irc-proto) and bump the dev-dependencies.

Note that they are still some libraries which need to be updated:
 - bytes 0.5 => 0.6 (for irc-proto)
 - tokio 0.2 => 0.3 (for irc and irc-proto)
 - tokio-util 0.3 => 0.4 (for irc and irc-proto)
 - tokio-rustls 0.14 => 0.20 (for irc)

But I wasn't brave enough... I never used tokio 0.3 and I am not even confident with the 0.2 version.
Is it maybe better if some else can have a look first.