### PR TITLE
Bump to Tokio 0.3.0 and clean up a few dependencies

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -36,7 +36,7 @@ yaml = ["yaml_config"]
 
 proxy = ["tokio-socks"]
 
-tls-native = ["native-tls", "tokio-tls"]
+tls-native = ["native-tls", "tokio-native-tls"]
 tls-rust = ["tokio-rustls", "webpki-roots"]
 
 
@@ -52,8 +52,8 @@ log = "0.4.0"
 parking_lot = "0.11.0"
 pin-utils = "0.1.0-alpha.4"
 thiserror = "1.0.0"
-tokio = { version = "0.2.0", features = ["macros", "net", "stream", "time"] }
-tokio-util = { version = "0.3.0", features = ["codec"] }
+tokio = { version = "0.3.0", features = ["net", "stream", "time"] }
+tokio-util = { version = "0.4.0", features = ["codec"] }
 
 # Feature - Config
 serde = { version = "1.0.0", optional = true }
@@ -67,8 +67,8 @@ tokio-socks = { version = "0.3.0", optional = true }
 
 # Feature - TLS
 native-tls = { version = "0.2.0", optional = true }
-tokio-rustls = { version = "0.14.0", optional = true }
-tokio-tls = { version = "0.3.0", optional = true }
+tokio-rustls = { version = "0.20.0", optional = true }
+tokio-native-tls = { version = "0.2.0", optional = true }
 webpki-roots = { version = "0.20.0", optional = true }
 
 
@@ -78,6 +78,7 @@ args = "2.0.0"
 env_logger = "0.7.0"
 futures = "0.3.0"
 getopts = "0.2.0"
+tokio = { version = "0.3.0", features = ["rt", "rt-multi-thread", "macros", "net", "stream", "time"] }
 
 
 [[example]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -41,15 +41,12 @@ tls-rust = ["tokio-rustls", "webpki-roots"]
 
 
 [dependencies]
-bufstream = "0.1.0"
-bytes = "0.5.0"
 chrono = "0.4.0"
 encoding = "0.2.0"
 futures-util = { version = "0.3.0", default-features = false, features = ["sink"] }
 irc-proto = { version = "0.14.0", path = "irc-proto" }
 log = "0.4.0"
 parking_lot = "0.11.0"
-pin-utils = "0.1.0-alpha.4"
 thiserror = "1.0.0"
 tokio = { version = "0.3.0", features = ["net", "stream", "time", "sync"] }
 tokio-util = { version = "0.4.0", features = ["codec"] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -45,14 +45,13 @@ bufstream = "0.1.0"
 bytes = "0.5.0"
 chrono = "0.4.0"
 encoding = "0.2.0"
-futures-channel = "0.3.0"
-futures-util = { version = "0.3.0", features = ["sink"] }
+futures-util = { version = "0.3.0", default-features = false, features = ["sink"] }
 irc-proto = { version = "0.14.0", path = "irc-proto" }
 log = "0.4.0"
 parking_lot = "0.11.0"
 pin-utils = "0.1.0-alpha.4"
 thiserror = "1.0.0"
-tokio = { version = "0.3.0", features = ["net", "stream", "time"] }
+tokio = { version = "0.3.0", features = ["net", "stream", "time", "sync"] }
 tokio-util = { version = "0.4.0", features = ["codec"] }
 
 # Feature - Config

--- a/irc-proto/Cargo.toml
+++ b/irc-proto/Cargo.toml
@@ -21,5 +21,5 @@ encoding = "0.2.0"
 thiserror = "1.0.0"
 
 bytes = { version = "0.5.0", optional = true }
-tokio = { version = "0.2.0", optional = true }
-tokio-util = { version = "0.3.0", features = ["codec"], optional = true }
+tokio = { version = "0.3.0", optional = true }
+tokio-util = { version = "0.4.0", features = ["codec"], optional = true }

--- a/src/client/conn.rs
+++ b/src/client/conn.rs
@@ -1,5 +1,4 @@
 //! A module providing IRC connections for use by `IrcServer`s.
-use futures_channel::mpsc::UnboundedSender;
 use futures_util::{sink::Sink, stream::Stream};
 use std::{
     fmt,
@@ -7,6 +6,7 @@ use std::{
     task::{Context, Poll},
 };
 use tokio::net::TcpStream;
+use tokio::sync::mpsc::UnboundedSender;
 use tokio_util::codec::Framed;
 
 #[cfg(feature = "proxy")]

--- a/src/client/mock.rs
+++ b/src/client/mock.rs
@@ -3,7 +3,7 @@ use std::{
     pin::Pin,
     task::{Context, Poll},
 };
-use tokio::io::{AsyncRead, AsyncWrite};
+use tokio::io::{AsyncRead, AsyncWrite, ReadBuf};
 
 /// A fake stream for testing network applications backed by buffers.
 #[derive(Clone, Debug)]
@@ -41,9 +41,11 @@ impl AsyncRead for MockStream {
     fn poll_read(
         mut self: Pin<&mut Self>,
         _: &mut Context<'_>,
-        buf: &mut [u8],
-    ) -> Poll<io::Result<usize>> {
-        Poll::Ready(self.as_mut().received.read(buf))
+        buf: &mut ReadBuf<'_>,
+    ) -> Poll<io::Result<()>> {
+        let n = self.as_mut().received.read(buf.initialize_unfilled())?;
+        buf.advance(n);
+        Poll::Ready(Ok(()))
     }
 }
 

--- a/src/client/mod.rs
+++ b/src/client/mod.rs
@@ -95,326 +95,338 @@ pub mod transport;
 
 macro_rules! pub_state_base {
     () => {
-    /// Changes the modes for the specified target.
-    pub fn send_mode<S, T>(&self, target: S, modes: &[Mode<T>]) -> error::Result<()>
-    where
-        S: fmt::Display,
-        T: ModeType,
-    {
-        self.send(T::mode(&target.to_string(), modes))
-    }
-
-    /// Joins the specified channel or chanlist.
-    pub fn send_join<S>(&self, chanlist: S) -> error::Result<()>
-    where
-        S: fmt::Display,
-    {
-        self.send(JOIN(chanlist.to_string(), None, None))
-    }
-
-    /// Joins the specified channel or chanlist using the specified key or keylist.
-    pub fn send_join_with_keys<S1, S2>(&self, chanlist: &str, keylist: &str) -> error::Result<()>
-    where
-        S1: fmt::Display,
-        S2: fmt::Display,
-    {
-        self.send(JOIN(chanlist.to_string(), Some(keylist.to_string()), None))
-    }
-
-    /// Sends a notice to the specified target.
-    pub fn send_notice<S1, S2>(&self, target: S1, message: S2) -> error::Result<()>
-    where
-        S1: fmt::Display,
-        S2: fmt::Display,
-    {
-        let message = message.to_string();
-        for line in message.split("\r\n") {
-            self.send(NOTICE(target.to_string(), line.to_string()))?
+        /// Changes the modes for the specified target.
+        pub fn send_mode<S, T>(&self, target: S, modes: &[Mode<T>]) -> error::Result<()>
+        where
+            S: fmt::Display,
+            T: ModeType,
+        {
+            self.send(T::mode(&target.to_string(), modes))
         }
-        Ok(())
-    }
-    }
+
+        /// Joins the specified channel or chanlist.
+        pub fn send_join<S>(&self, chanlist: S) -> error::Result<()>
+        where
+            S: fmt::Display,
+        {
+            self.send(JOIN(chanlist.to_string(), None, None))
+        }
+
+        /// Joins the specified channel or chanlist using the specified key or keylist.
+        pub fn send_join_with_keys<S1, S2>(
+            &self,
+            chanlist: &str,
+            keylist: &str,
+        ) -> error::Result<()>
+        where
+            S1: fmt::Display,
+            S2: fmt::Display,
+        {
+            self.send(JOIN(chanlist.to_string(), Some(keylist.to_string()), None))
+        }
+
+        /// Sends a notice to the specified target.
+        pub fn send_notice<S1, S2>(&self, target: S1, message: S2) -> error::Result<()>
+        where
+            S1: fmt::Display,
+            S2: fmt::Display,
+        {
+            let message = message.to_string();
+            for line in message.split("\r\n") {
+                self.send(NOTICE(target.to_string(), line.to_string()))?
+            }
+            Ok(())
+        }
+    };
 }
 
 macro_rules! pub_sender_base {
     () => {
-    /// Sends a request for a list of server capabilities for a specific IRCv3 version.
-    pub fn send_cap_ls(&self, version: NegotiationVersion) -> error::Result<()> {
-        self.send(Command::CAP(
-            None,
-            LS,
-            match version {
-                NegotiationVersion::V301 => None,
-                NegotiationVersion::V302 => Some("302".to_owned()),
-            },
-            None,
-        ))
-    }
-
-    /// Sends an IRCv3 capabilities request for the specified extensions.
-    pub fn send_cap_req(&self, extensions: &[Capability]) -> error::Result<()> {
-        let append = |mut s: String, c| {
-            s.push_str(c);
-            s.push(' ');
-            s
-        };
-        let mut exts = extensions
-            .iter()
-            .map(|c| c.as_ref())
-            .fold(String::new(), append);
-        let len = exts.len() - 1;
-        exts.truncate(len);
-        self.send(CAP(None, REQ, None, Some(exts)))
-    }
-
-    /// Sends a SASL AUTHENTICATE message with the specified data.
-    pub fn send_sasl<S: fmt::Display>(&self, data: S) -> error::Result<()> {
-        self.send(AUTHENTICATE(data.to_string()))
-    }
-
-    /// Sends a SASL AUTHENTICATE request to use the PLAIN mechanism.
-    pub fn send_sasl_plain(&self) -> error::Result<()> {
-        self.send_sasl("PLAIN")
-    }
-
-    /// Sends a SASL AUTHENTICATE request to use the EXTERNAL mechanism.
-    pub fn send_sasl_external(&self) -> error::Result<()> {
-        self.send_sasl("EXTERNAL")
-    }
-
-    /// Sends a SASL AUTHENTICATE request to abort authentication.
-    pub fn send_sasl_abort(&self) -> error::Result<()> {
-        self.send_sasl("*")
-    }
-
-    /// Sends a PONG with the specified message.
-    pub fn send_pong<S>(&self, msg: S) -> error::Result<()>
-    where
-        S: fmt::Display,
-    {
-        self.send(PONG(msg.to_string(), None))
-    }
-
-    /// Parts the specified channel or chanlist.
-    pub fn send_part<S>(&self, chanlist: S) -> error::Result<()>
-    where
-        S: fmt::Display,
-    {
-        self.send(PART(chanlist.to_string(), None))
-    }
-
-    /// Attempts to oper up using the specified username and password.
-    pub fn send_oper<S1, S2>(&self, username: S1, password: S2) -> error::Result<()>
-    where
-        S1: fmt::Display,
-        S2: fmt::Display,
-    {
-        self.send(OPER(username.to_string(), password.to_string()))
-    }
-
-    /// Sends a message to the specified target. If the message contains IRC newlines (`\r\n`), it
-    /// will automatically be split and sent as multiple separate `PRIVMSG`s to the specified
-    /// target. If you absolutely must avoid this behavior, you can do
-    /// `client.send(PRIVMSG(target, message))` directly.
-    pub fn send_privmsg<S1, S2>(&self, target: S1, message: S2) -> error::Result<()>
-    where
-        S1: fmt::Display,
-        S2: fmt::Display,
-    {
-        let message = message.to_string();
-        for line in message.split("\r\n") {
-            self.send(PRIVMSG(target.to_string(), line.to_string()))?
+        /// Sends a request for a list of server capabilities for a specific IRCv3 version.
+        pub fn send_cap_ls(&self, version: NegotiationVersion) -> error::Result<()> {
+            self.send(Command::CAP(
+                None,
+                LS,
+                match version {
+                    NegotiationVersion::V301 => None,
+                    NegotiationVersion::V302 => Some("302".to_owned()),
+                },
+                None,
+            ))
         }
-        Ok(())
-    }
 
-    /// Sets the topic of a channel or requests the current one.
-    /// If `topic` is an empty string, it won't be included in the message.
-    pub fn send_topic<S1, S2>(&self, channel: S1, topic: S2) -> error::Result<()>
-    where
-        S1: fmt::Display,
-        S2: fmt::Display,
-    {
-        let topic = topic.to_string();
-        self.send(TOPIC(
-            channel.to_string(),
-            if topic.is_empty() { None } else { Some(topic) },
-        ))
-    }
-
-    /// Kills the target with the provided message.
-    pub fn send_kill<S1, S2>(&self, target: S1, message: S2) -> error::Result<()>
-    where
-        S1: fmt::Display,
-        S2: fmt::Display,
-    {
-        self.send(KILL(target.to_string(), message.to_string()))
-    }
-
-    /// Kicks the listed nicknames from the listed channels with a comment.
-    /// If `message` is an empty string, it won't be included in the message.
-    pub fn send_kick<S1, S2, S3>(
-        &self,
-        chanlist: S1,
-        nicklist: S2,
-        message: S3,
-    ) -> error::Result<()>
-    where
-        S1: fmt::Display,
-        S2: fmt::Display,
-        S3: fmt::Display,
-    {
-        let message = message.to_string();
-        self.send(KICK(
-            chanlist.to_string(),
-            nicklist.to_string(),
-            if message.is_empty() {
-                None
-            } else {
-                Some(message)
-            },
-        ))
-    }
-
-    /// Changes the mode of the target by force.
-    /// If `modeparams` is an empty string, it won't be included in the message.
-    pub fn send_samode<S1, S2, S3>(&self, target: S1, mode: S2, modeparams: S3) -> error::Result<()>
-    where
-        S1: fmt::Display,
-        S2: fmt::Display,
-        S3: fmt::Display,
-    {
-        let modeparams = modeparams.to_string();
-        self.send(SAMODE(
-            target.to_string(),
-            mode.to_string(),
-            if modeparams.is_empty() {
-                None
-            } else {
-                Some(modeparams)
-            },
-        ))
-    }
-
-    /// Forces a user to change from the old nickname to the new nickname.
-    pub fn send_sanick<S1, S2>(&self, old_nick: S1, new_nick: S2) -> error::Result<()>
-    where
-        S1: fmt::Display,
-        S2: fmt::Display,
-    {
-        self.send(SANICK(old_nick.to_string(), new_nick.to_string()))
-    }
-
-    /// Invites a user to the specified channel.
-    pub fn send_invite<S1, S2>(&self, nick: S1, chan: S2) -> error::Result<()>
-    where
-        S1: fmt::Display,
-        S2: fmt::Display,
-    {
-        self.send(INVITE(nick.to_string(), chan.to_string()))
-    }
-
-    /// Quits the server entirely with a message.
-    /// This defaults to `Powered by Rust.` if none is specified.
-    pub fn send_quit<S>(&self, msg: S) -> error::Result<()>
-    where
-        S: fmt::Display,
-    {
-        let msg = msg.to_string();
-        self.send(QUIT(Some(if msg.is_empty() {
-            "Powered by Rust.".to_string()
-        } else {
-            msg
-        })))
-    }
-
-    /// Sends a CTCP-escaped message to the specified target.
-    /// This requires the CTCP feature to be enabled.
-    #[cfg(feature = "ctcp")]
-    pub fn send_ctcp<S1, S2>(&self, target: S1, msg: S2) -> error::Result<()>
-    where
-        S1: fmt::Display,
-        S2: fmt::Display,
-    {
-        let msg = msg.to_string();
-        for line in msg.split("\r\n") {
-            self.send(PRIVMSG(target.to_string(), format!("\u{001}{}\u{001}", line)))?
+        /// Sends an IRCv3 capabilities request for the specified extensions.
+        pub fn send_cap_req(&self, extensions: &[Capability]) -> error::Result<()> {
+            let append = |mut s: String, c| {
+                s.push_str(c);
+                s.push(' ');
+                s
+            };
+            let mut exts = extensions
+                .iter()
+                .map(|c| c.as_ref())
+                .fold(String::new(), append);
+            let len = exts.len() - 1;
+            exts.truncate(len);
+            self.send(CAP(None, REQ, None, Some(exts)))
         }
-        Ok(())
-    }
 
-    /// Sends an action command to the specified target.
-    /// This requires the CTCP feature to be enabled.
-    #[cfg(feature = "ctcp")]
-    pub fn send_action<S1, S2>(&self, target: S1, msg: S2) -> error::Result<()>
-    where
-        S1: fmt::Display,
-        S2: fmt::Display,
-    {
-        self.send_ctcp(target, &format!("ACTION {}", msg.to_string())[..])
-    }
+        /// Sends a SASL AUTHENTICATE message with the specified data.
+        pub fn send_sasl<S: fmt::Display>(&self, data: S) -> error::Result<()> {
+            self.send(AUTHENTICATE(data.to_string()))
+        }
 
-    /// Sends a finger request to the specified target.
-    /// This requires the CTCP feature to be enabled.
-    #[cfg(feature = "ctcp")]
-    pub fn send_finger<S: fmt::Display>(&self, target: S) -> error::Result<()>
-    where
-        S: fmt::Display,
-    {
-        self.send_ctcp(target, "FINGER")
-    }
+        /// Sends a SASL AUTHENTICATE request to use the PLAIN mechanism.
+        pub fn send_sasl_plain(&self) -> error::Result<()> {
+            self.send_sasl("PLAIN")
+        }
 
-    /// Sends a version request to the specified target.
-    /// This requires the CTCP feature to be enabled.
-    #[cfg(feature = "ctcp")]
-    pub fn send_version<S>(&self, target: S) -> error::Result<()>
-    where
-        S: fmt::Display,
-    {
-        self.send_ctcp(target, "VERSION")
-    }
+        /// Sends a SASL AUTHENTICATE request to use the EXTERNAL mechanism.
+        pub fn send_sasl_external(&self) -> error::Result<()> {
+            self.send_sasl("EXTERNAL")
+        }
 
-    /// Sends a source request to the specified target.
-    /// This requires the CTCP feature to be enabled.
-    #[cfg(feature = "ctcp")]
-    pub fn send_source<S>(&self, target: S) -> error::Result<()>
-    where
-        S: fmt::Display,
-    {
-        self.send_ctcp(target, "SOURCE")
-    }
+        /// Sends a SASL AUTHENTICATE request to abort authentication.
+        pub fn send_sasl_abort(&self) -> error::Result<()> {
+            self.send_sasl("*")
+        }
 
-    /// Sends a user info request to the specified target.
-    /// This requires the CTCP feature to be enabled.
-    #[cfg(feature = "ctcp")]
-    pub fn send_user_info<S>(&self, target: S) -> error::Result<()>
-    where
-        S: fmt::Display,
-    {
-        self.send_ctcp(target, "USERINFO")
-    }
+        /// Sends a PONG with the specified message.
+        pub fn send_pong<S>(&self, msg: S) -> error::Result<()>
+        where
+            S: fmt::Display,
+        {
+            self.send(PONG(msg.to_string(), None))
+        }
 
-    /// Sends a finger request to the specified target.
-    /// This requires the CTCP feature to be enabled.
-    #[cfg(feature = "ctcp")]
-    pub fn send_ctcp_ping<S>(&self, target: S) -> error::Result<()>
-    where
-        S: fmt::Display,
-    {
-        let time = Local::now();
-        self.send_ctcp(target, &format!("PING {}", time.timestamp())[..])
-    }
+        /// Parts the specified channel or chanlist.
+        pub fn send_part<S>(&self, chanlist: S) -> error::Result<()>
+        where
+            S: fmt::Display,
+        {
+            self.send(PART(chanlist.to_string(), None))
+        }
 
-    /// Sends a time request to the specified target.
-    /// This requires the CTCP feature to be enabled.
-    #[cfg(feature = "ctcp")]
-    pub fn send_time<S>(&self, target: S) -> error::Result<()>
-    where
-        S: fmt::Display,
-    {
-        self.send_ctcp(target, "TIME")
-    }
-    }
+        /// Attempts to oper up using the specified username and password.
+        pub fn send_oper<S1, S2>(&self, username: S1, password: S2) -> error::Result<()>
+        where
+            S1: fmt::Display,
+            S2: fmt::Display,
+        {
+            self.send(OPER(username.to_string(), password.to_string()))
+        }
+
+        /// Sends a message to the specified target. If the message contains IRC newlines (`\r\n`), it
+        /// will automatically be split and sent as multiple separate `PRIVMSG`s to the specified
+        /// target. If you absolutely must avoid this behavior, you can do
+        /// `client.send(PRIVMSG(target, message))` directly.
+        pub fn send_privmsg<S1, S2>(&self, target: S1, message: S2) -> error::Result<()>
+        where
+            S1: fmt::Display,
+            S2: fmt::Display,
+        {
+            let message = message.to_string();
+            for line in message.split("\r\n") {
+                self.send(PRIVMSG(target.to_string(), line.to_string()))?
+            }
+            Ok(())
+        }
+
+        /// Sets the topic of a channel or requests the current one.
+        /// If `topic` is an empty string, it won't be included in the message.
+        pub fn send_topic<S1, S2>(&self, channel: S1, topic: S2) -> error::Result<()>
+        where
+            S1: fmt::Display,
+            S2: fmt::Display,
+        {
+            let topic = topic.to_string();
+            self.send(TOPIC(
+                channel.to_string(),
+                if topic.is_empty() { None } else { Some(topic) },
+            ))
+        }
+
+        /// Kills the target with the provided message.
+        pub fn send_kill<S1, S2>(&self, target: S1, message: S2) -> error::Result<()>
+        where
+            S1: fmt::Display,
+            S2: fmt::Display,
+        {
+            self.send(KILL(target.to_string(), message.to_string()))
+        }
+
+        /// Kicks the listed nicknames from the listed channels with a comment.
+        /// If `message` is an empty string, it won't be included in the message.
+        pub fn send_kick<S1, S2, S3>(
+            &self,
+            chanlist: S1,
+            nicklist: S2,
+            message: S3,
+        ) -> error::Result<()>
+        where
+            S1: fmt::Display,
+            S2: fmt::Display,
+            S3: fmt::Display,
+        {
+            let message = message.to_string();
+            self.send(KICK(
+                chanlist.to_string(),
+                nicklist.to_string(),
+                if message.is_empty() {
+                    None
+                } else {
+                    Some(message)
+                },
+            ))
+        }
+
+        /// Changes the mode of the target by force.
+        /// If `modeparams` is an empty string, it won't be included in the message.
+        pub fn send_samode<S1, S2, S3>(
+            &self,
+            target: S1,
+            mode: S2,
+            modeparams: S3,
+        ) -> error::Result<()>
+        where
+            S1: fmt::Display,
+            S2: fmt::Display,
+            S3: fmt::Display,
+        {
+            let modeparams = modeparams.to_string();
+            self.send(SAMODE(
+                target.to_string(),
+                mode.to_string(),
+                if modeparams.is_empty() {
+                    None
+                } else {
+                    Some(modeparams)
+                },
+            ))
+        }
+
+        /// Forces a user to change from the old nickname to the new nickname.
+        pub fn send_sanick<S1, S2>(&self, old_nick: S1, new_nick: S2) -> error::Result<()>
+        where
+            S1: fmt::Display,
+            S2: fmt::Display,
+        {
+            self.send(SANICK(old_nick.to_string(), new_nick.to_string()))
+        }
+
+        /// Invites a user to the specified channel.
+        pub fn send_invite<S1, S2>(&self, nick: S1, chan: S2) -> error::Result<()>
+        where
+            S1: fmt::Display,
+            S2: fmt::Display,
+        {
+            self.send(INVITE(nick.to_string(), chan.to_string()))
+        }
+
+        /// Quits the server entirely with a message.
+        /// This defaults to `Powered by Rust.` if none is specified.
+        pub fn send_quit<S>(&self, msg: S) -> error::Result<()>
+        where
+            S: fmt::Display,
+        {
+            let msg = msg.to_string();
+            self.send(QUIT(Some(if msg.is_empty() {
+                "Powered by Rust.".to_string()
+            } else {
+                msg
+            })))
+        }
+
+        /// Sends a CTCP-escaped message to the specified target.
+        /// This requires the CTCP feature to be enabled.
+        #[cfg(feature = "ctcp")]
+        pub fn send_ctcp<S1, S2>(&self, target: S1, msg: S2) -> error::Result<()>
+        where
+            S1: fmt::Display,
+            S2: fmt::Display,
+        {
+            let msg = msg.to_string();
+            for line in msg.split("\r\n") {
+                self.send(PRIVMSG(
+                    target.to_string(),
+                    format!("\u{001}{}\u{001}", line),
+                ))?
+            }
+            Ok(())
+        }
+
+        /// Sends an action command to the specified target.
+        /// This requires the CTCP feature to be enabled.
+        #[cfg(feature = "ctcp")]
+        pub fn send_action<S1, S2>(&self, target: S1, msg: S2) -> error::Result<()>
+        where
+            S1: fmt::Display,
+            S2: fmt::Display,
+        {
+            self.send_ctcp(target, &format!("ACTION {}", msg.to_string())[..])
+        }
+
+        /// Sends a finger request to the specified target.
+        /// This requires the CTCP feature to be enabled.
+        #[cfg(feature = "ctcp")]
+        pub fn send_finger<S: fmt::Display>(&self, target: S) -> error::Result<()>
+        where
+            S: fmt::Display,
+        {
+            self.send_ctcp(target, "FINGER")
+        }
+
+        /// Sends a version request to the specified target.
+        /// This requires the CTCP feature to be enabled.
+        #[cfg(feature = "ctcp")]
+        pub fn send_version<S>(&self, target: S) -> error::Result<()>
+        where
+            S: fmt::Display,
+        {
+            self.send_ctcp(target, "VERSION")
+        }
+
+        /// Sends a source request to the specified target.
+        /// This requires the CTCP feature to be enabled.
+        #[cfg(feature = "ctcp")]
+        pub fn send_source<S>(&self, target: S) -> error::Result<()>
+        where
+            S: fmt::Display,
+        {
+            self.send_ctcp(target, "SOURCE")
+        }
+
+        /// Sends a user info request to the specified target.
+        /// This requires the CTCP feature to be enabled.
+        #[cfg(feature = "ctcp")]
+        pub fn send_user_info<S>(&self, target: S) -> error::Result<()>
+        where
+            S: fmt::Display,
+        {
+            self.send_ctcp(target, "USERINFO")
+        }
+
+        /// Sends a finger request to the specified target.
+        /// This requires the CTCP feature to be enabled.
+        #[cfg(feature = "ctcp")]
+        pub fn send_ctcp_ping<S>(&self, target: S) -> error::Result<()>
+        where
+            S: fmt::Display,
+        {
+            let time = Local::now();
+            self.send_ctcp(target, &format!("PING {}", time.timestamp())[..])
+        }
+
+        /// Sends a time request to the specified target.
+        /// This requires the CTCP feature to be enabled.
+        #[cfg(feature = "ctcp")]
+        pub fn send_time<S>(&self, target: S) -> error::Result<()>
+        where
+            S: fmt::Display,
+        {
+            self.send_ctcp(target, "TIME")
+        }
+    };
 }
 
 /// A stream of `Messages` received from an IRC server via an `Client`.

--- a/src/client/transport.rs
+++ b/src/client/transport.rs
@@ -20,7 +20,7 @@ use tokio_util::codec::Framed;
 use crate::{
     client::data::Config,
     error,
-    proto::{Command, Response, IrcCodec, Message},
+    proto::{Command, IrcCodec, Message, Response},
 };
 
 /// Pinger-based futures helper.

--- a/src/client/transport.rs
+++ b/src/client/transport.rs
@@ -13,7 +13,7 @@ use futures_channel::mpsc::UnboundedSender;
 use futures_util::{future::Future, ready, sink::Sink, stream::Stream};
 use tokio::{
     io::{AsyncRead, AsyncWrite},
-    time::{self, Delay, Interval},
+    time::{self, Interval, Sleep},
 };
 use tokio_util::codec::Framed;
 
@@ -31,7 +31,7 @@ struct Pinger {
     /// The amount of time to wait before timing out from no ping response.
     ping_timeout: Duration,
     /// The instant that the last ping was sent to the server.
-    ping_deadline: Option<Delay>,
+    ping_deadline: Option<Sleep>,
     /// The interval at which to send pings.
     ping_interval: Interval,
 }
@@ -98,7 +98,7 @@ impl Pinger {
     /// Set the ping deadline.
     fn set_deadline(&mut self) {
         if self.ping_deadline.is_none() {
-            let ping_deadline = time::delay_for(self.ping_timeout);
+            let ping_deadline = time::sleep(self.ping_timeout);
             self.ping_deadline = Some(ping_deadline);
         }
     }

--- a/src/client/transport.rs
+++ b/src/client/transport.rs
@@ -9,8 +9,8 @@ use std::{
 };
 
 use chrono::prelude::*;
-use futures_channel::mpsc::UnboundedSender;
 use futures_util::{future::Future, ready, sink::Sink, stream::Stream};
+use tokio::sync::mpsc::UnboundedSender;
 use tokio::{
     io::{AsyncRead, AsyncWrite},
     time::{self, Interval, Sleep},
@@ -77,8 +77,7 @@ impl Pinger {
 
     /// Send a pong.
     fn send_pong(&mut self, data: &str) -> error::Result<()> {
-        self.tx
-            .unbounded_send(Command::PONG(data.to_owned(), None).into())?;
+        self.tx.send(Command::PONG(data.to_owned(), None).into())?;
         Ok(())
     }
 
@@ -89,8 +88,7 @@ impl Pinger {
         // Creates new ping data using the local timestamp.
         let data = format!("{}", Local::now().timestamp());
 
-        self.tx
-            .unbounded_send(Command::PING(data.clone(), None).into())?;
+        self.tx.send(Command::PING(data.clone(), None).into())?;
 
         Ok(())
     }

--- a/src/error.rs
+++ b/src/error.rs
@@ -3,11 +3,8 @@
 use std::io::Error as IoError;
 use std::sync::mpsc::RecvError;
 
-use futures_channel::{
-    mpsc::{SendError, TrySendError},
-    oneshot::Canceled,
-};
 use thiserror::Error;
+use tokio::sync::mpsc::error::{SendError, TrySendError};
 
 #[cfg(feature = "tls-rust")]
 use tokio_rustls::webpki::InvalidDNSNameError;
@@ -45,11 +42,11 @@ pub enum Error {
 
     /// An internal asynchronous channel closed.
     #[error("an async channel closed")]
-    AsyncChannelClosed(#[source] SendError),
+    AsyncChannelClosed,
 
     /// An internal oneshot channel closed.
     #[error("a oneshot channel closed")]
-    OneShotCanceled(#[source] Canceled),
+    OneShotCanceled,
 
     /// Error for invalid configurations.
     #[error("invalid config: {}", path)]
@@ -205,20 +202,14 @@ impl From<RecvError> for Error {
     }
 }
 
-impl From<SendError> for Error {
-    fn from(e: SendError) -> Error {
-        Error::AsyncChannelClosed(e)
+impl<T> From<SendError<T>> for Error {
+    fn from(_: SendError<T>) -> Error {
+        Error::AsyncChannelClosed
     }
 }
 
 impl<T> From<TrySendError<T>> for Error {
-    fn from(e: TrySendError<T>) -> Error {
-        Error::AsyncChannelClosed(e.into_send_error())
-    }
-}
-
-impl From<Canceled> for Error {
-    fn from(e: Canceled) -> Error {
-        Error::OneShotCanceled(e)
+    fn from(_: TrySendError<T>) -> Error {
+        Error::AsyncChannelClosed
     }
 }


### PR DESCRIPTION
Not a ton of changes this release. Definitely not as many as `0.2` 🎉 

Removed dependencies:
* `futures-channel`
* `pin-utils` - seems to no longer used, and tokio comes with [tokio::pin](https://docs.rs/tokio/0/tokio/macro.pin.html) now.