### PR TITLE
irc-proto: allow empty mode

### DIFF
--- a/irc-proto/src/mode.rs
+++ b/irc-proto/src/mode.rs
@@ -287,10 +287,8 @@ where
                 })
             }
             None => {
-                return Err(InvalidModeString {
-                    string: pieces.join(" ").to_owned(),
-                    cause: MissingModeModifier,
-                })
+                // No modifier
+                return Ok(res);
             }
         };
 
@@ -318,9 +316,32 @@ where
 
         Ok(res)
     } else {
-        Err(InvalidModeString {
-            string: pieces.join(" ").to_owned(),
-            cause: MissingModeModifier,
-        })
+        // No modifier
+        Ok(res)
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use super::{ChannelMode, Mode};
+    use crate::Command;
+    use crate::Message;
+
+    #[test]
+    fn parse_channel_mode() {
+        let cmd = "MODE #foo +r".parse::<Message>().unwrap().command;
+        assert_eq!(
+            Command::ChannelMODE(
+                "#foo".to_string(),
+                vec![Mode::Plus(ChannelMode::RegisteredOnly, None)]
+            ),
+            cmd
+        );
+    }
+
+    #[test]
+    fn parse_no_mode() {
+        let cmd = "MODE #foo".parse::<Message>().unwrap().command;
+        assert_eq!(Command::ChannelMODE("#foo".to_string(), vec![]), cmd);
     }
 }


### PR DESCRIPTION
irc clients can query what modes a channel has by sending an empty mode
command

Closes #217.

Thanks for the reminder -- I've tried adding some basic test as there were none for mode, is that ok? Probably could add a bit more but it's a start.