### PR TITLE
Enable 'futures-util/alloc' feature

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -43,7 +43,7 @@ tls-rust = ["tokio-rustls", "webpki-roots"]
 [dependencies]
 chrono = "0.4.0"
 encoding = "0.2.0"
-futures-util = { version = "0.3.0", default-features = false, features = ["sink"] }
+futures-util = { version = "0.3.0", default-features = false, features = ["alloc", "sink"] }
 irc-proto = { version = "0.14.0", path = "irc-proto" }
 log = "0.4.0"
 parking_lot = "0.11.0"


### PR DESCRIPTION
`futures-util` requires its `alloc` feature to be enabled to use `SplitSink` and `SplitStream`, and since `default-features` is set to `false`, we need to enable it manually.