### PR TITLE
better errors for missing certificates

### DIFF
--- a/src/client/data/config.rs
+++ b/src/client/data/config.rs
@@ -224,7 +224,8 @@ impl Config {
         self
     }
 
-    fn path(&self) -> String {
+    /// Returns the location this Config was loaded from or `<none>`.
+    pub(crate) fn path(&self) -> String {
         self.path
             .as_ref()
             .map(|buf| buf.to_string_lossy().into_owned())

--- a/src/error.rs
+++ b/src/error.rs
@@ -144,6 +144,13 @@ pub enum ConfigError {
     /// Configuration does not specify a server.
     #[error("server not specified")]
     ServerNotSpecified,
+
+    /// The specified file could not be read.
+    #[error("could not read file {}", file)]
+    FileMissing {
+        /// The supposed location of the file.
+        file: String,
+    },
 }
 
 /// A wrapper that combines toml's serialization and deserialization errors.


### PR DESCRIPTION
Resolves #212.

This introduces a new `ConfigError` variant for when the configuration contains a path but the respective file cannot be read (could be because the file is missing or because of permission problems). This new variant is then used if a specified certificate file (server or client certificate) cannot be read.

To not duplicate code, I changed the visibility of `Config::path` to `pub(crate)` so it can be reused in the variants of `Connection::new_secured_transport`.

Not sure if or how to add tests for this.