### PR TITLE
Fix stringification of command suffixes with a leading colon

### DIFF
--- a/irc-proto/src/command.rs
+++ b/irc-proto/src/command.rs
@@ -209,7 +209,7 @@ fn stringify(cmd: &str, args: &[&str]) -> String {
         Some((suffix, args)) => {
             let args = args.join(" ");
             let sp = if args.is_empty() { "" } else { " " };
-            let co = if suffix.is_empty() || suffix.contains(' ') {
+            let co = if suffix.is_empty() || suffix.contains(' ') || suffix.starts_with(':') {
                 ":"
             } else {
                 ""

--- a/irc-proto/src/message.rs
+++ b/irc-proto/src/message.rs
@@ -547,4 +547,29 @@ mod test {
         let message = "@tag=\\:\\s\\\\\\r\\na :test PRIVMSG #test test\r\n";
         assert_eq!(msg, message);
     }
+
+    #[test]
+    fn to_message_with_colon_in_suffix() {
+        let msg = "PRIVMSG #test ::test"
+            .parse::<Message>()
+            .unwrap();
+        let message = Message {
+            tags: None,
+            prefix: None,
+            command: PRIVMSG("#test".to_string(), ":test".to_string())
+        };
+        assert_eq!(msg, message);
+    }
+
+    #[test]
+    fn to_string_with_colon_in_suffix() {
+        let msg = Message {
+            tags: None,
+            prefix: None,
+            command: PRIVMSG("#test".to_string(), ":test".to_string()),
+        }
+        .to_string();
+        let message = "PRIVMSG #test ::test\r\n";
+        assert_eq!(msg, message);
+    }
 }


### PR DESCRIPTION
Hello,

  irc-proto tries to canonicalize command suffixes by only inserting a leading colon when required.

  However, it fails to do so in one corner case (when the suffix itself starts with a colon), causing the leading colon to be gobbled up.
This fixes the corner case.

Cheers,