### PR TITLE
Fix all `cargo clippy` warnings.

### DIFF
--- a/examples/build-bot.rs
+++ b/examples/build-bot.rs
@@ -27,23 +27,20 @@ async fn main() -> irc::error::Result<()> {
     let mut stream = client.stream()?;
 
     while let Some(message) = stream.next().await.transpose()? {
-        match message.command {
-            Command::Response(Response::RPL_ISUPPORT, _) => {
-                client.send_privmsg(
-                    "#commits",
-                    format!(
-                        "[{}/{}] ({}) {} [{}]",
-                        repository_slug,
-                        branch,
-                        &commit[..7],
-                        commit_message,
-                        features,
-                    ),
-                )?;
+        if let Command::Response(Response::RPL_ISUPPORT, _) = message.command {
+            client.send_privmsg(
+                "#commits",
+                format!(
+                    "[{}/{}] ({}) {} [{}]",
+                    repository_slug,
+                    branch,
+                    &commit[..7],
+                    commit_message,
+                    features,
+                ),
+            )?;
 
-                client.send_quit("QUIT")?;
-            }
-            _ => (),
+            client.send_quit("QUIT")?;
         }
     }
 

--- a/examples/multiserver.rs
+++ b/examples/multiserver.rs
@@ -45,13 +45,10 @@ async fn main() -> irc::error::Result<()> {
 fn process_msg(sender: &Sender, message: Message) -> error::Result<()> {
     print!("{}", message);
 
-    match message.command {
-        Command::PRIVMSG(ref target, ref msg) => {
-            if msg.contains("pickles") {
-                sender.send_privmsg(target, "Hi!")?;
-            }
+    if let Command::PRIVMSG(ref target, ref msg) = message.command {
+        if msg.contains("pickles") {
+            sender.send_privmsg(target, "Hi!")?;
         }
-        _ => (),
     }
 
     Ok(())

--- a/examples/repeater.rs
+++ b/examples/repeater.rs
@@ -22,7 +22,7 @@ async fn main() -> irc::error::Result<()> {
         let message = stream.select_next_some().await?;
 
         if let Command::PRIVMSG(ref target, ref msg) = message.command {
-            if msg.starts_with(&*client.current_nickname()) {
+            if msg.starts_with(client.current_nickname()) {
                 let tokens: Vec<_> = msg.split(' ').collect();
                 if tokens.len() > 2 {
                     let n = tokens[0].len() + tokens[1].len() + 2;

--- a/examples/simple.rs
+++ b/examples/simple.rs
@@ -19,13 +19,10 @@ async fn main() -> irc::error::Result<()> {
     while let Some(message) = stream.next().await.transpose()? {
         print!("{}", message);
 
-        match message.command {
-            Command::PRIVMSG(ref target, ref msg) => {
-                if msg.contains(client.current_nickname()) {
-                    sender.send_privmsg(target, "Hi!")?;
-                }
+        if let Command::PRIVMSG(ref target, ref msg) = message.command {
+            if msg.contains(client.current_nickname()) {
+                sender.send_privmsg(target, "Hi!")?;
             }
-            _ => (),
         }
     }
 

--- a/examples/simple_plaintext.rs
+++ b/examples/simple_plaintext.rs
@@ -20,13 +20,10 @@ async fn main() -> irc::error::Result<()> {
     while let Some(message) = stream.next().await.transpose()? {
         print!("{}", message);
 
-        match message.command {
-            Command::PRIVMSG(ref target, ref msg) => {
-                if msg.contains(client.current_nickname()) {
-                    sender.send_privmsg(target, "Hi!")?;
-                }
+        if let Command::PRIVMSG(ref target, ref msg) = message.command {
+            if msg.contains(client.current_nickname()) {
+                sender.send_privmsg(target, "Hi!")?;
             }
-            _ => (),
         }
     }
 

--- a/examples/simple_proxy.rs
+++ b/examples/simple_proxy.rs
@@ -22,13 +22,10 @@ async fn main() -> irc::error::Result<()> {
     while let Some(message) = stream.next().await.transpose()? {
         print!("{}", message);
 
-        match message.command {
-            Command::PRIVMSG(ref target, ref msg) => {
-                if msg.contains(client.current_nickname()) {
-                    sender.send_privmsg(target, "Hi!")?;
-                }
+        if let Command::PRIVMSG(ref target, ref msg) = message.command {
+            if msg.contains(client.current_nickname()) {
+                sender.send_privmsg(target, "Hi!")?;
             }
-            _ => (),
         }
     }
 

--- a/irc-proto/src/colors.rs
+++ b/irc-proto/src/colors.rs
@@ -65,11 +65,11 @@ impl Parser {
                 false
             }
             Text => !FORMAT_CHARACTERS.contains(&cur),
-            ColorCode if cur.is_digit(10) => {
+            ColorCode if cur.is_ascii_digit() => {
                 self.state = Foreground1(cur);
                 false
             }
-            Foreground1('0') if cur.is_digit(10) => {
+            Foreground1('0') if cur.is_ascii_digit() => {
                 // can consume another digit if previous char was 0.
                 self.state = Foreground2;
                 false
@@ -91,7 +91,7 @@ impl Parser {
                 self.state = Comma;
                 false
             }
-            Comma if (cur.is_digit(10)) => {
+            Comma if (cur.is_ascii_digit()) => {
                 self.state = Background1(cur);
                 false
             }

--- a/irc-proto/src/command.rs
+++ b/irc-proto/src/command.rs
@@ -231,13 +231,13 @@ impl<'a> From<&'a Command> for String {
                 "MODE {}{}",
                 u,
                 m.iter().fold(String::new(), |mut acc, mode| {
-                    acc.push_str(" ");
+                    acc.push(' ');
                     acc.push_str(&mode.to_string());
                     acc
                 })
             ),
-            Command::SERVICE(ref n, ref r, ref d, ref t, ref re, ref i) => {
-                stringify("SERVICE", &[n, r, d, t, re, i])
+            Command::SERVICE(ref nick, ref r0, ref dist, ref typ, ref r1, ref info) => {
+                stringify("SERVICE", &[nick, r0, dist, typ, r1, info])
             }
             Command::QUIT(Some(ref m)) => stringify("QUIT", &[m]),
             Command::QUIT(None) => stringify("QUIT", &[]),
@@ -252,7 +252,7 @@ impl<'a> From<&'a Command> for String {
                 "MODE {}{}",
                 u,
                 m.iter().fold(String::new(), |mut acc, mode| {
-                    acc.push_str(" ");
+                    acc.push(' ');
                     acc.push_str(&mode.to_string());
                     acc
                 })
@@ -445,12 +445,10 @@ impl Command {
         } else if cmd.eq_ignore_ascii_case("MODE") {
             if args.is_empty() {
                 raw(cmd, args)
+            } else if args[0].is_channel_name() {
+                Command::ChannelMODE(args[0].to_owned(), Mode::as_channel_modes(&args[1..])?)
             } else {
-                if args[0].is_channel_name() {
-                    Command::ChannelMODE(args[0].to_owned(), Mode::as_channel_modes(&args[1..])?)
-                } else {
-                    Command::UserMODE(args[0].to_owned(), Mode::as_user_modes(&args[1..])?)
-                }
+                Command::UserMODE(args[0].to_owned(), Mode::as_user_modes(&args[1..])?)
             }
         } else if cmd.eq_ignore_ascii_case("SERVICE") {
             if args.len() != 6 {
@@ -665,7 +663,7 @@ impl Command {
             } else if args.len() == 1 {
                 Command::WHO(Some(args[0].to_owned()), None)
             } else if args.len() == 2 {
-                Command::WHO(Some(args[0].to_owned()), Some(&args[1][..] == "o"))
+                Command::WHO(Some(args[0].to_owned()), Some(args[1] == "o"))
             } else {
                 raw(cmd, args)
             }
@@ -907,13 +905,12 @@ impl Command {
                 raw(cmd, args)
             }
         } else if cmd.eq_ignore_ascii_case("METADATA") {
-            if args.len() == 2 {
-                match args[1].parse() {
+            match args.len() {
+                2 => match args[1].parse() {
                     Ok(c) => Command::METADATA(args[0].to_owned(), Some(c), None),
                     Err(_) => raw(cmd, args),
-                }
-            } else if args.len() > 2 {
-                match args[1].parse() {
+                },
+                3.. => match args[1].parse() {
                     Ok(c) => Command::METADATA(
                         args[0].to_owned(),
                         Some(c),
@@ -930,9 +927,8 @@ impl Command {
                             raw(cmd, args)
                         }
                     }
-                }
-            } else {
-                raw(cmd, args)
+                },
+                _ => raw(cmd, args),
             }
         } else if cmd.eq_ignore_ascii_case("MONITOR") {
             if args.len() == 2 {

--- a/irc-proto/src/message.rs
+++ b/irc-proto/src/message.rs
@@ -290,19 +290,20 @@ fn unescape_tag_value(value: &str) -> String {
     let mut unescaped = String::with_capacity(value.len());
     let mut iter = value.chars();
     while let Some(c) = iter.next() {
-        if c == '\\' {
+        let r = if c == '\\' {
             match iter.next() {
-                Some(':') => unescaped.push(';'),
-                Some('s') => unescaped.push(' '),
-                Some('\\') => unescaped.push('\\'),
-                Some('r') => unescaped.push('\r'),
-                Some('n') => unescaped.push('\n'),
-                Some(c) => unescaped.push(c),
+                Some(':') => ';',
+                Some('s') => ' ',
+                Some('\\') => '\\',
+                Some('r') => '\r',
+                Some('n') => '\n',
+                Some(c) => c,
                 None => break,
             }
         } else {
-            unescaped.push(c);
-        }
+            c
+        };
+        unescaped.push(r);
     }
     unescaped
 }

--- a/irc-proto/src/message.rs
+++ b/irc-proto/src/message.rs
@@ -58,7 +58,7 @@ impl Message {
         args: Vec<&str>,
     ) -> Result<Message, error::MessageParseError> {
         Ok(Message {
-            tags: tags,
+            tags,
             prefix: prefix.map(|p| p.into()),
             command: Command::new(command, args)?,
         })
@@ -134,7 +134,7 @@ impl Message {
                 ret.push_str(&tag.0);
                 if let Some(ref value) = tag.1 {
                     ret.push('=');
-                    escape_tag_value(&mut ret, &value);
+                    escape_tag_value(&mut ret, value);
                 }
                 ret.push(';');
             }

--- a/irc-proto/src/mode.rs
+++ b/irc-proto/src/mode.rs
@@ -139,11 +139,7 @@ impl ModeType for ChannelMode {
     fn takes_arg(&self) -> bool {
         use self::ChannelMode::*;
 
-        match *self {
-            Ban | Exception | Limit | InviteException | Key | Founder | Admin | Oper | Halfop
-            | Voice => true,
-            _ => false,
-        }
+        matches!(*self, Ban | Exception | Limit | InviteException | Key | Founder | Admin | Oper | Halfop | Voice)
     }
 
     fn from_char(c: char) -> ChannelMode {
@@ -234,10 +230,10 @@ where
 {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         match *self {
-            Mode::Plus(ref mode, Some(ref arg)) => write!(f, "{}{} {}", "+", mode, arg),
-            Mode::Minus(ref mode, Some(ref arg)) => write!(f, "{}{} {}", "-", mode, arg),
-            Mode::Plus(ref mode, None) => write!(f, "{}{}", "+", mode),
-            Mode::Minus(ref mode, None) => write!(f, "{}{}", "-", mode),
+            Mode::Plus(ref mode, Some(ref arg)) => write!(f, "+{} {}", mode, arg),
+            Mode::Minus(ref mode, Some(ref arg)) => write!(f, "-{} {}", mode, arg),
+            Mode::Plus(ref mode, None) => write!(f, "+{}", mode),
+            Mode::Minus(ref mode, None) => write!(f, "-{}", mode),
         }
     }
 }
@@ -282,7 +278,7 @@ where
             Some('-') => Minus,
             Some(c) => {
                 return Err(InvalidModeString {
-                    string: pieces.join(" ").to_owned(),
+                    string: pieces.join(" "),
                     cause: InvalidModeModifier { modifier: c },
                 })
             }
@@ -313,12 +309,11 @@ where
         }
 
         // TODO: if there are extra args left, this should error
-
-        Ok(res)
     } else {
         // No modifier
-        Ok(res)
-    }
+    };
+
+    Ok(res)
 }
 
 #[cfg(test)]

--- a/irc-proto/src/mode.rs
+++ b/irc-proto/src/mode.rs
@@ -139,7 +139,18 @@ impl ModeType for ChannelMode {
     fn takes_arg(&self) -> bool {
         use self::ChannelMode::*;
 
-        matches!(*self, Ban | Exception | Limit | InviteException | Key | Founder | Admin | Oper | Halfop | Voice)
+        matches!(
+            *self,
+            Ban | Exception
+                | Limit
+                | InviteException
+                | Key
+                | Founder
+                | Admin
+                | Oper
+                | Halfop
+                | Voice
+        )
     }
 
     fn from_char(c: char) -> ChannelMode {

--- a/src/client/conn.rs
+++ b/src/client/conn.rs
@@ -156,7 +156,7 @@ impl Connection {
         let stream = Self::new_stream(config).await?;
         let framed = Framed::new(stream, IrcCodec::new(config.encoding())?);
 
-        Ok(Transport::new(&config, framed, tx))
+        Ok(Transport::new(config, framed, tx))
     }
 
     #[cfg(all(feature = "tls-native", not(feature = "tls-rust")))]
@@ -188,7 +188,7 @@ impl Connection {
                 let mut client_cert_data = vec![];
                 file.read_to_end(&mut client_cert_data)?;
                 let client_cert_pass = config.client_cert_pass();
-                let pkcs12_archive = Identity::from_pkcs12(&client_cert_data, &client_cert_pass)?;
+                let pkcs12_archive = Identity::from_pkcs12(&client_cert_data, client_cert_pass)?;
                 builder.identity(pkcs12_archive);
                 log::info!(
                     "Using {} for client certificate authentication.",
@@ -215,7 +215,7 @@ impl Connection {
         let stream = connector.connect(domain, stream).await?;
         let framed = Framed::new(stream, IrcCodec::new(config.encoding())?);
 
-        Ok(Transport::new(&config, framed, tx))
+        Ok(Transport::new(config, framed, tx))
     }
 
     #[cfg(feature = "tls-rust")]
@@ -337,7 +337,7 @@ impl Connection {
         let stream = connector.connect(domain, stream).await?;
         let framed = Framed::new(stream, IrcCodec::new(config.encoding())?);
 
-        Ok(Transport::new(&config, framed, tx))
+        Ok(Transport::new(config, framed, tx))
     }
 
     async fn new_mocked_transport(
@@ -363,7 +363,7 @@ impl Connection {
         let stream = MockStream::new(&initial);
         let framed = Framed::new(stream, IrcCodec::new(config.encoding())?);
 
-        Ok(Transport::new(&config, framed, tx))
+        Ok(Transport::new(config, framed, tx))
     }
 
     /// Gets a view of the internal logging if and only if this connection is using a mock stream.

--- a/src/client/data/config.rs
+++ b/src/client/data/config.rs
@@ -399,11 +399,10 @@ impl Config {
 
     /// Gets the nickname specified in the configuration.
     pub fn nickname(&self) -> Result<&str> {
-        self.nickname.as_deref()
-            .ok_or_else(|| InvalidConfig {
-                path: self.path(),
-                cause: ConfigError::NicknameNotSpecified,
-            })
+        self.nickname.as_deref().ok_or_else(|| InvalidConfig {
+            path: self.path(),
+            cause: ConfigError::NicknameNotSpecified,
+        })
     }
 
     /// Gets the bot's nickserv password specified in the configuration.
@@ -436,11 +435,10 @@ impl Config {
 
     /// Gets the address of the server specified in the configuration.
     pub fn server(&self) -> Result<&str> {
-        self.server.as_deref()
-            .ok_or_else(|| InvalidConfig {
-                path: self.path(),
-                cause: ConfigError::ServerNotSpecified,
-            })
+        self.server.as_deref().ok_or_else(|| InvalidConfig {
+            path: self.path(),
+            cause: ConfigError::ServerNotSpecified,
+        })
     }
 
     /// Gets the port of the server specified in the configuration.

--- a/src/client/data/config.rs
+++ b/src/client/data/config.rs
@@ -661,16 +661,16 @@ mod test {
     #[allow(unused)]
     fn test_config() -> Config {
         Config {
-            owners: vec![format!("test")],
-            nickname: Some(format!("test")),
-            username: Some(format!("test")),
-            realname: Some(format!("test")),
+            owners: vec!["test".to_string()],
+            nickname: Some("test".to_string()),
+            username: Some("test".to_string()),
+            realname: Some("test".to_string()),
             password: Some(String::new()),
-            umodes: Some(format!("+BR")),
-            server: Some(format!("irc.test.net")),
+            umodes: Some("+BR".to_string()),
+            server: Some("irc.test.net".to_string()),
             port: Some(6667),
-            encoding: Some(format!("UTF-8")),
-            channels: vec![format!("#test"), format!("#test2")],
+            encoding: Some("UTF-8".to_string()),
+            channels: vec!["#test".to_string(), "#test2".to_string()],
 
             ..Default::default()
         }
@@ -679,7 +679,7 @@ mod test {
     #[test]
     fn is_owner() {
         let cfg = Config {
-            owners: vec![format!("test"), format!("test2")],
+            owners: vec!["test".to_string(), "test2".to_string()],
             ..Default::default()
         };
         assert!(cfg.is_owner("test"));
@@ -692,7 +692,7 @@ mod test {
         let cfg = Config {
             options: {
                 let mut map = HashMap::new();
-                map.insert(format!("testing"), format!("test"));
+                map.insert("testing".to_string(), "test".to_string());
                 map
             },
             ..Default::default()

--- a/src/client/data/config.rs
+++ b/src/client/data/config.rs
@@ -394,14 +394,12 @@ impl Config {
 
     /// Determines whether or not the nickname provided is the owner of the bot.
     pub fn is_owner(&self, nickname: &str) -> bool {
-        self.owners.iter().find(|n| *n == nickname).is_some()
+        self.owners.iter().any(|n| n == nickname)
     }
 
     /// Gets the nickname specified in the configuration.
     pub fn nickname(&self) -> Result<&str> {
-        self.nickname
-            .as_ref()
-            .map(String::as_str)
+        self.nickname.as_deref()
             .ok_or_else(|| InvalidConfig {
                 path: self.path(),
                 cause: ConfigError::NicknameNotSpecified,
@@ -425,7 +423,7 @@ impl Config {
     pub fn username(&self) -> &str {
         self.username
             .as_ref()
-            .map_or(self.nickname().unwrap_or("user"), |s| &s)
+            .map_or(self.nickname().unwrap_or("user"), |s| s)
     }
 
     /// Gets the real name specified in the configuration.
@@ -433,14 +431,12 @@ impl Config {
     pub fn real_name(&self) -> &str {
         self.realname
             .as_ref()
-            .map_or(self.nickname().unwrap_or("irc"), |s| &s)
+            .map_or(self.nickname().unwrap_or("irc"), |s| s)
     }
 
     /// Gets the address of the server specified in the configuration.
     pub fn server(&self) -> Result<&str> {
-        self.server
-            .as_ref()
-            .map(String::as_str)
+        self.server.as_deref()
             .ok_or_else(|| InvalidConfig {
                 path: self.path(),
                 cause: ConfigError::ServerNotSpecified,
@@ -517,7 +513,7 @@ impl Config {
     /// Gets the path to the TLS certificate in DER format if specified.
     #[cfg(any(feature = "tls-native", feature = "tls-rust"))]
     pub fn cert_path(&self) -> Option<&str> {
-        self.cert_path.as_ref().map(String::as_str)
+        self.cert_path.as_deref()
     }
 
     /// Gets whether or not to dangerously accept invalid certificates.
@@ -532,7 +528,7 @@ impl Config {
     /// Gets the path to the client authentication certificate in DER format if specified.
     #[cfg(any(feature = "tls-native", feature = "tls-rust"))]
     pub fn client_cert_path(&self) -> Option<&str> {
-        self.client_cert_path.as_ref().map(String::as_str)
+        self.client_cert_path.as_deref()
     }
 
     /// Gets the password to the client authentication certificate.
@@ -544,7 +540,7 @@ impl Config {
     /// Gets the encoding to use for this connection. This requires the encode feature to work.
     /// This defaults to UTF-8 when not specified.
     pub fn encoding(&self) -> &str {
-        self.encoding.as_ref().map_or("UTF-8", |s| &s)
+        self.encoding.as_ref().map_or("UTF-8", |s| s)
     }
 
     /// Gets the channels to join upon connection.
@@ -574,7 +570,7 @@ impl Config {
     /// This defaults to `irc:version:env` when not specified.
     /// For example, `irc:0.12.0:Compiled with rustc`
     pub fn version(&self) -> &str {
-        self.version.as_ref().map_or(crate::VERSION_STR, |s| &s)
+        self.version.as_ref().map_or(crate::VERSION_STR, |s| s)
     }
 
     /// Gets the string to be sent in response to CTCP SOURCE requests.
@@ -624,7 +620,7 @@ impl Config {
     /// Gets the NickServ command sequence to recover a nickname.
     /// This defaults to `["GHOST"]` when not specified.
     pub fn ghost_sequence(&self) -> Option<&[String]> {
-        self.ghost_sequence.as_ref().map(Vec::as_slice)
+        self.ghost_sequence.as_deref()
     }
 
     /// Looks up the specified string in the options map.
@@ -642,7 +638,7 @@ impl Config {
     /// This defaults to false when not specified.
     /// This has no effect if `use_mock_connection` is not `true`.
     pub fn mock_initial_value(&self) -> &str {
-        self.mock_initial_value.as_ref().map_or("", |s| &s)
+        self.mock_initial_value.as_ref().map_or("", |s| s)
     }
 }
 

--- a/src/client/data/user.rs
+++ b/src/client/data/user.rs
@@ -248,7 +248,7 @@ mod test {
     fn create_user() {
         let user = User::new("~owner");
         let exp = User {
-            nickname: format!("owner"),
+            nickname: "owner".to_string(),
             username: None,
             hostname: None,
             highest_access_level: Owner,
@@ -263,7 +263,7 @@ mod test {
     fn create_user_complex() {
         let user = User::new("~&+user");
         let exp = User {
-            nickname: format!("user"),
+            nickname: "user".to_string(),
             username: None,
             hostname: None,
             highest_access_level: Owner,

--- a/src/client/data/user.rs
+++ b/src/client/data/user.rs
@@ -31,9 +31,9 @@ impl User {
         let username = state.find('@').map(|i| state[..i].to_owned());
         let hostname = state.find('@').map(|i| state[i + 1..].to_owned());
         User {
-            nickname: nickname,
-            username: username,
-            hostname: hostname,
+            nickname,
+            username,
+            hostname,
             access_levels: {
                 let mut ranks = ranks.clone();
                 ranks.push(AccessLevel::Member);

--- a/src/client/mod.rs
+++ b/src/client/mod.rs
@@ -113,11 +113,7 @@ macro_rules! pub_state_base {
         }
 
         /// Joins the specified channel or chanlist using the specified key or keylist.
-        pub fn send_join_with_keys<S1, S2>(
-            &self,
-            chanlist: &str,
-            keylist: &str,
-        ) -> error::Result<()>
+        pub fn send_join_with_keys<S1, S2>(&self, chanlist: S1, keylist: S2) -> error::Result<()>
         where
             S1: fmt::Display,
             S2: fmt::Display,

--- a/src/client/mod.rs
+++ b/src/client/mod.rs
@@ -1305,7 +1305,6 @@ mod test {
         .await?;
         let res = client.stream()?.try_collect::<Vec<_>>().await;
         if let Err(Error::NoUsableNick) = res {
-            
         } else {
             panic!("expected error when no valid nicks were specified")
         }

--- a/src/client/mod.rs
+++ b/src/client/mod.rs
@@ -1114,12 +1114,12 @@ mod test {
 
     pub fn test_config() -> Config {
         Config {
-            owners: vec![format!("test")],
-            nickname: Some(format!("test")),
-            alt_nicks: vec![format!("test2")],
-            server: Some(format!("irc.test.net")),
-            channels: vec![format!("#test"), format!("#test2")],
-            user_info: Some(format!("Testing.")),
+            owners: vec!["test".to_string()],
+            nickname: Some("test".to_string()),
+            alt_nicks: vec!["test2".to_string()],
+            server: Some("irc.test.net".to_string()),
+            channels: vec!["#test".to_string(), "#test2".to_string()],
+            user_info: Some("Testing.".to_string()),
             use_mock_connection: true,
             ..Default::default()
         }
@@ -1180,8 +1180,8 @@ mod test {
         let value = ":irc.test.net 376 test :End of /MOTD command.\r\n";
         let mut client = Client::from_config(Config {
             mock_initial_value: Some(value.to_owned()),
-            nick_password: Some(format!("password")),
-            channels: vec![format!("#test"), format!("#test2")],
+            nick_password: Some("password".to_string()),
+            channels: vec!["#test".to_string(), "#test2".to_string()],
             ..test_config()
         })
         .await?;
@@ -1199,11 +1199,11 @@ mod test {
         let value = ":irc.test.net 376 test :End of /MOTD command\r\n";
         let mut client = Client::from_config(Config {
             mock_initial_value: Some(value.to_owned()),
-            nickname: Some(format!("test")),
-            channels: vec![format!("#test"), format!("#test2")],
+            nickname: Some("test".to_string()),
+            channels: vec!["#test".to_string(), "#test2".to_string()],
             channel_keys: {
                 let mut map = HashMap::new();
-                map.insert(format!("#test2"), format!("password"));
+                map.insert("#test2".to_string(), "password".to_string());
                 map
             },
             ..test_config()
@@ -1223,10 +1223,10 @@ mod test {
                      :irc.test.net 376 test2 :End of /MOTD command.\r\n";
         let mut client = Client::from_config(Config {
             mock_initial_value: Some(value.to_owned()),
-            nickname: Some(format!("test")),
-            alt_nicks: vec![format!("test2")],
-            nick_password: Some(format!("password")),
-            channels: vec![format!("#test"), format!("#test2")],
+            nickname: Some("test".to_string()),
+            alt_nicks: vec!["test2".to_string()],
+            nick_password: Some("password".to_string()),
+            channels: vec!["#test".to_string(), "#test2".to_string()],
             should_ghost: true,
             ..test_config()
         })
@@ -1246,12 +1246,12 @@ mod test {
                      :irc.test.net 376 test2 :End of /MOTD command.\r\n";
         let mut client = Client::from_config(Config {
             mock_initial_value: Some(value.to_owned()),
-            nickname: Some(format!("test")),
-            alt_nicks: vec![format!("test2")],
-            nick_password: Some(format!("password")),
-            channels: vec![format!("#test"), format!("#test2")],
+            nickname: Some("test".to_string()),
+            alt_nicks: vec!["test2".to_string()],
+            nick_password: Some("password".to_string()),
+            channels: vec!["#test".to_string(), "#test2".to_string()],
             should_ghost: true,
-            ghost_sequence: Some(vec![format!("RECOVER"), format!("RELEASE")]),
+            ghost_sequence: Some(vec!["RECOVER".to_string(), "RELEASE".to_string()]),
             ..test_config()
         })
         .await?;
@@ -1270,9 +1270,9 @@ mod test {
         let value = ":irc.test.net 376 test :End of /MOTD command.\r\n";
         let mut client = Client::from_config(Config {
             mock_initial_value: Some(value.to_owned()),
-            nickname: Some(format!("test")),
-            umodes: Some(format!("+B")),
-            channels: vec![format!("#test"), format!("#test2")],
+            nickname: Some("test".to_string()),
+            umodes: Some("+B".to_string()),
+            channels: vec!["#test".to_string(), "#test2".to_string()],
             ..test_config()
         })
         .await?;
@@ -1319,7 +1319,7 @@ mod test {
     async fn send() -> Result<()> {
         let mut client = Client::from_config(test_config()).await?;
         assert!(client
-            .send(PRIVMSG(format!("#test"), format!("Hi there!")))
+            .send(PRIVMSG("#test".to_string(), "Hi there!".to_string()))
             .is_ok());
         client.stream()?.collect().await?;
         assert_eq!(
@@ -1333,7 +1333,10 @@ mod test {
     async fn send_no_newline_injection() -> Result<()> {
         let mut client = Client::from_config(test_config()).await?;
         assert!(client
-            .send(PRIVMSG(format!("#test"), format!("Hi there!\r\nJOIN #bad")))
+            .send(PRIVMSG(
+                "#test".to_string(),
+                "Hi there!\r\nJOIN #bad".to_string()
+            ))
             .is_ok());
         client.stream()?.collect().await?;
         assert_eq!(
@@ -1391,7 +1394,7 @@ mod test {
         assert_eq!(client.list_channels(), Some(vec!["#test".to_owned()]));
         // we ignore the result, as soon as we queue an outgoing message we
         // update client state, regardless if the queue is available or not.
-        let _ = client.send(PART(format!("#test"), None));
+        let _ = client.send(PART("#test".to_string(), None));
         assert_eq!(client.list_channels(), Some(vec![]));
         Ok(())
     }
@@ -1520,8 +1523,8 @@ mod test {
         let value = ":test!test@test PRIVMSG #test :\u{001}\r\n";
         let mut client = Client::from_config(Config {
             mock_initial_value: Some(value.to_owned()),
-            nickname: Some(format!("test")),
-            channels: vec![format!("#test"), format!("#test2")],
+            nickname: Some("test".to_string()),
+            channels: vec!["#test".to_string(), "#test2".to_string()],
             ..test_config()
         })
         .await?;
@@ -1664,8 +1667,8 @@ mod test {
     #[tokio::test]
     async fn identify_with_password() -> Result<()> {
         let mut client = Client::from_config(Config {
-            nickname: Some(format!("test")),
-            password: Some(format!("password")),
+            nickname: Some("test".to_string()),
+            password: Some("password".to_string()),
             ..test_config()
         })
         .await?;

--- a/src/client/transport.rs
+++ b/src/client/transport.rs
@@ -96,7 +96,7 @@ impl Pinger {
 
         let mut this = self.project();
 
-        this.tx.send(Command::PING(data.clone(), None).into())?;
+        this.tx.send(Command::PING(data, None).into())?;
 
         if this.ping_deadline.is_none() {
             let ping_deadline = time::sleep(*this.ping_timeout);
@@ -118,10 +118,8 @@ impl Future for Pinger {
             }
         }
 
-        if let Poll::Ready(_) = self.as_mut().project().ping_interval.poll_tick(cx) {
-            if *self.as_mut().project().enabled {
-                self.as_mut().send_ping()?;
-            }
+        if self.as_mut().project().ping_interval.poll_tick(cx).is_ready() && *self.as_mut().project().enabled {
+            self.as_mut().send_ping()?;
         }
 
         Poll::Pending

--- a/src/client/transport.rs
+++ b/src/client/transport.rs
@@ -118,7 +118,14 @@ impl Future for Pinger {
             }
         }
 
-        if self.as_mut().project().ping_interval.poll_tick(cx).is_ready() && *self.as_mut().project().enabled {
+        if self
+            .as_mut()
+            .project()
+            .ping_interval
+            .poll_tick(cx)
+            .is_ready()
+            && *self.as_mut().project().enabled
+        {
             self.as_mut().send_ping()?;
         }
 


### PR DESCRIPTION
This PR doesn't change this library's behavior. It only fixes linter warnings.