### PR TITLE
New option: dangerously_accept_invalid_certs

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -65,7 +65,7 @@ tokio-socks = { version = "0.5.1", optional = true }
 
 # Feature - TLS
 native-tls = { version = "0.2.0", optional = true }
-tokio-rustls = { version = "0.22.0", optional = true }
+tokio-rustls = { version = "0.22.0", features = ["dangerous_configuration"], optional = true }
 tokio-native-tls = { version = "0.3.0", optional = true }
 webpki-roots = { version = "0.20.0", optional = true }
 

--- a/src/client/data/config.rs
+++ b/src/client/data/config.rs
@@ -137,6 +137,13 @@ pub struct Config {
     #[cfg(any(feature = "tls-native", feature = "tls-rust"))]
     #[cfg_attr(feature = "serde", serde(skip_serializing_if = "Option::is_none"))]
     pub client_cert_pass: Option<String>,
+    /// On `true`, all certificate validations are skipped. Defaults to `false`.
+    ///
+    /// # Warning
+    /// You should think very carefully before using this method. If invalid hostnames are trusted, *any* valid
+    /// certificate for *any* site will be trusted for use. This introduces significant vulnerabilities, and should
+    /// only be used as a last resort.
+    pub dangerously_accept_invalid_certs: Option<bool>,
     /// The encoding type used for this connection.
     /// This is typically UTF-8, but could be something else.
     #[cfg_attr(feature = "serde", serde(skip_serializing_if = "Option::is_none"))]
@@ -511,6 +518,12 @@ impl Config {
     #[cfg(any(feature = "tls-native", feature = "tls-rust"))]
     pub fn cert_path(&self) -> Option<&str> {
         self.cert_path.as_ref().map(String::as_str)
+    }
+
+    /// Gets whether or not to dangerously accept invalid certificates.
+    /// This defaults to `false` when not specified.
+    pub fn dangerously_accept_invalid_certs(&self) -> bool {
+        self.dangerously_accept_invalid_certs.as_ref().cloned().unwrap_or(false)
     }
 
     /// Gets the path to the client authentication certificate in DER format if specified.


### PR DESCRIPTION
This patch adds an option to dangerously ignore all ceritificate verifications. This option must be used with extreme caution and should only be used as a last resort.

Closes #209, #230

Co-authored-by: Hyeon Kim <simnalamburt@gmail.com>

CC @quite