### PR TITLE
Allow for custom message parsers

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,10 +24,11 @@ members = ["./", "irc-proto/"]
 
 [features]
 # warning: adding the `essentials` feature to default breaks semver. I should turn this into a reductive feature once I know that the code works. I'm just using a normal feature temporarily because otherwise VS Code won't show errors properly.
-default = ["ctcp", "tls-native", "toml_config", "essentials"]
+default = ["ctcp", "tls-native", "toml_config", "essentials", "codec-tests"]
 ctcp = []
 nochanlists = []
 essentials = []
+codec-tests = ["anyhow"]
 
 json_config = ["serde", "serde/derive", "serde_derive", "serde_json"]
 toml_config = ["serde", "serde/derive", "serde_derive", "toml"]
@@ -71,6 +72,8 @@ tokio-rustls = { version = "0.22.0", optional = true }
 tokio-native-tls = { version = "0.3.0", optional = true }
 webpki-roots = { version = "0.20.0", optional = true }
 
+# Feature - Test Suite
+anyhow = { version = "1.0.0", optional = true }
 
 [dev-dependencies]
 anyhow = "1.0.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,13 +19,15 @@ is-it-maintained-open-issues = { repository = "aatxe/irc" }
 
 
 [workspace]
-members = [ "./", "irc-proto/" ]
+members = ["./", "irc-proto/"]
 
 
 [features]
-default = ["ctcp", "tls-native", "toml_config"]
+# warning: adding the `essentials` feature to default breaks semver. I should turn this into a reductive feature once I know that the code works. I'm just using a normal feature temporarily because otherwise VS Code won't show errors properly.
+default = ["ctcp", "tls-native", "toml_config", "essentials"]
 ctcp = []
 nochanlists = []
+essentials = []
 
 json_config = ["serde", "serde/derive", "serde_derive", "serde_json"]
 toml_config = ["serde", "serde/derive", "serde_derive", "toml"]
@@ -82,9 +84,34 @@ tokio = { version = "1.0.0", features = ["rt", "rt-multi-thread", "macros", "net
 [[example]]
 name = "simple_proxy"
 path = "examples/simple_proxy.rs"
-required-features = ["proxy"]
+required-features = ["proxy", "essentials"]
 
 [[example]]
 name = "simple_plaintext"
 path = "examples/simple_plaintext.rs"
-required-features = ["tls-native"]
+required-features = ["tls-native", "essentials"]
+
+[[example]]
+name = "tweeter"
+path = "examples/tweeter.rs"
+required-features = ["essentials"]
+
+[[example]]
+name = "tooter"
+path = "examples/tooter.rs"
+required-features = ["essentials"]
+
+[[example]]
+name = "repeater"
+path = "examples/repeater.rs"
+required-features = ["essentials"]
+
+[[example]]
+name = "build_bot"
+path = "examples/build-bot.rs"
+required-features = ["essentials"]
+
+[[example]]
+name = "multiserver"
+path = "examples/multiserver.rs"
+required-features = ["essentials"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -87,12 +87,6 @@ getopts = "0.2.0"
 tokio = { version = "1.0.0", features = ["rt", "rt-multi-thread", "macros", "net", "time"] }
 no-parse-codec = { path = "no-parse-codec" }
 
-
-[[example]]
-name = "no_parse_codec"
-path = "examples/no_parse_codec.rs"
-required-features = []
-
 [[example]]
 name = "simple_proxy"
 path = "examples/simple_proxy.rs"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,7 +19,7 @@ is-it-maintained-open-issues = { repository = "aatxe/irc" }
 
 
 [workspace]
-members = ["./", "irc-proto/"]
+members = ["./", "irc-proto/", "irc-interface/"]
 
 
 [features]
@@ -48,13 +48,13 @@ chrono = "0.4.0"
 encoding = "0.2.0"
 futures-util = { version = "0.3.0", default-features = false, features = ["alloc", "sink"] }
 irc-proto = { version = "0.15.0", path = "irc-proto" }
+irc-interface = { version = "0.0.1", path = "irc-interface" }
 log = "0.4.0"
 parking_lot = "0.11.0"
 thiserror = "1.0.0"
 pin-project = "1.0.2"
 tokio = { version = "1.0.0", features = ["net", "time", "sync"] }
 tokio-stream = "0.1.0"
-tokio-util = { version = "0.6.0", features = ["codec"] }
 
 # Feature - Config
 serde = { version = "1.0.0", optional = true }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,14 +19,17 @@ is-it-maintained-open-issues = { repository = "aatxe/irc" }
 
 
 [workspace]
-members = ["./", "irc-proto/", "irc-interface/"]
+members = ["./", "irc-proto/", "irc-interface/", "no-parse-codec/"]
 
 
 [features]
 # warning: adding the `essentials` feature to default breaks semver. I should turn this into a reductive feature once I know that the code works. I'm just using a normal feature temporarily because otherwise VS Code won't show errors properly.
-default = ["ctcp", "tls-native", "toml_config", "essentials", "codec-tests"]
-ctcp = []
+default = ["ctcp", "tls-native", "toml_config", "codec-tests"]
+ctcp = ["essentials"]
 nochanlists = []
+# we differentiate between "barebones" mode and "essentials" mode. 
+# in "barebones" mode, the only supported features are those strictly required to run an IRC client
+# enabling the "essentials" feature provides other features that would be required from a useful IRC client
 essentials = []
 codec-tests = ["anyhow"]
 
@@ -82,7 +85,13 @@ env_logger = "0.7.0"
 futures = "0.3.0"
 getopts = "0.2.0"
 tokio = { version = "1.0.0", features = ["rt", "rt-multi-thread", "macros", "net", "time"] }
+no-parse-codec = { path = "no-parse-codec" }
 
+
+[[example]]
+name = "no_parse_codec"
+path = "examples/no_parse_codec.rs"
+required-features = []
 
 [[example]]
 name = "simple_proxy"

--- a/examples/no_parse_codec.rs
+++ b/examples/no_parse_codec.rs
@@ -1,0 +1,28 @@
+//! Creates a IRC Client using the `no-parse-codec`.
+//! This means that messages are received as Strings rather than [`irc_proto::Command`] objects.
+//! This only works if you run it with `--no-default-features`.
+
+use futures::prelude::*;
+use irc::client::prelude::*;
+use no_parse_codec::*;
+
+#[tokio::main]
+async fn main() -> irc::error::Result<()> {
+    let config = Config {
+        nickname: Some("pickles".to_owned()),
+        server: Some("chat.freenode.net".to_owned()),
+        channels: vec!["#rust-spam".to_owned()],
+        ..Default::default()
+    };
+
+    let mut client = Client::<NoParseCodec>::from_config_with_codec(config).await?;
+    client.identify()?;
+
+    let mut stream = client.stream()?;
+
+    while let Some(message) = stream.next().await.transpose()? {
+        print!("{}", message);
+    }
+
+    Ok(())
+}

--- a/examples/no_parse_codec.rs
+++ b/examples/no_parse_codec.rs
@@ -2,6 +2,8 @@
 //! This means that messages are received as Strings rather than [`irc_proto::Command`] objects.
 //! This only works if you run it with `--no-default-features`.
 
+// TODO: This should be an integration test for the `no_parse_codec` crate
+
 use futures::prelude::*;
 use irc::client::prelude::*;
 use no_parse_codec::*;

--- a/examples/simple.rs
+++ b/examples/simple.rs
@@ -26,7 +26,7 @@ async fn main() -> irc::error::Result<()> {
                     sender.send_privmsg(target, "Hi!")?;
                     #[cfg(not(feature = "essentials"))]
                     sender.send(
-                        <irc_proto::Message as irc::client::data::codec::InternalIrcMessageOutgoing>::new_raw(
+                        <irc_proto::Message as irc_interface::InternalIrcMessageOutgoing>::new_raw(
                             "PRIVMSG".to_owned(),
                             vec![target.to_owned(), "Hi!".to_owned()],
                         ),

--- a/examples/simple.rs
+++ b/examples/simple.rs
@@ -22,6 +22,7 @@ async fn main() -> irc::error::Result<()> {
         match message.command {
             Command::PRIVMSG(ref target, ref msg) => {
                 if msg.contains(client.current_nickname()) {
+                    #[cfg(feature = "essentials")]
                     sender.send_privmsg(target, "Hi!")?;
                 }
             }

--- a/examples/simple.rs
+++ b/examples/simple.rs
@@ -24,6 +24,13 @@ async fn main() -> irc::error::Result<()> {
                 if msg.contains(client.current_nickname()) {
                     #[cfg(feature = "essentials")]
                     sender.send_privmsg(target, "Hi!")?;
+                    #[cfg(not(feature = "essentials"))]
+                    sender.send(
+                        <irc_proto::Message as irc::client::data::codec::InternalIrcMessageOutgoing>::new_raw(
+                            "PRIVMSG".to_owned(),
+                            vec![target.to_owned(), "Hi!".to_owned()],
+                        ),
+                    )?;
                 }
             }
             _ => (),

--- a/irc-interface/Cargo.toml
+++ b/irc-interface/Cargo.toml
@@ -1,0 +1,17 @@
+[package]
+name = "irc-interface"
+version = "0.0.1"
+description = "Interface to make `irc` compatible with multiple protocol implementations."
+authors = ["Aaron Weiss <aweiss@hey.com>", "snowpoke <hello@snowpoke.ink>"]
+license = "MPL-2.0"
+keywords = ["irc", "trait", "interface"]
+categories = ["network-programming"]
+documentation = "https://docs.rs/irc-proto/"
+repository = "https://github.com/aatxe/irc"
+edition = "2021"
+
+[badges]
+travis-ci = { repository = "aatxe/irc" }
+
+[dependencies]
+tokio-util = { version = "0.6.0", features = ["codec"] }

--- a/irc-interface/Cargo.toml
+++ b/irc-interface/Cargo.toml
@@ -14,4 +14,6 @@ edition = "2021"
 travis-ci = { repository = "aatxe/irc" }
 
 [dependencies]
+bytes = "1.2.1"
+encoding = "0.2.33"
 tokio-util = { version = "0.6.0", features = ["codec"] }

--- a/irc-interface/src/lib.rs
+++ b/irc-interface/src/lib.rs
@@ -10,7 +10,10 @@ pub mod line;
 
 /// A codec that can be used to encode or decode IRC messages.
 pub trait MessageCodec:
-    Decoder<Item = <Self as MessageCodec>::MsgItem> + Encoder<<Self as MessageCodec>::MsgItem> + Sized
+    Decoder<Item = <Self as MessageCodec>::MsgItem>
+    + Encoder<<Self as MessageCodec>::MsgItem>
+    + Debug
+    + Sized
 {
     /// The type of the message that this codec expects for messages that we want to send.
     type MsgItem: Display

--- a/irc-interface/src/lib.rs
+++ b/irc-interface/src/lib.rs
@@ -3,7 +3,10 @@
 
 use std::fmt::{Debug, Display};
 
+pub use line::LineCodec;
 pub use tokio_util::codec::{Decoder, Encoder, Framed};
+
+pub mod line;
 
 /// A codec that can be used to encode or decode IRC messages.
 pub trait MessageCodec:

--- a/irc-interface/src/lib.rs
+++ b/irc-interface/src/lib.rs
@@ -1,0 +1,145 @@
+//! A trait that describes a codec that can be used to encode or decode IRC messages.
+//! At the moment, this is just a wrapper around [`tokio_util::codec::Decoder`] and [`tokio_util::codec::Encoder`].
+
+use std::fmt::{Debug, Display};
+
+pub use tokio_util::codec::{Decoder, Encoder, Framed};
+
+/// A codec that can be used to encode or decode IRC messages.
+pub trait MessageCodec:
+    Decoder<Item = <Self as MessageCodec>::MsgItem> + Encoder<<Self as MessageCodec>::MsgItem> + Sized
+{
+    /// The type of the message that this codec expects for messages that we want to send.
+    type MsgItem: Display
+        + Debug
+        + Clone
+        + Unpin
+        + Sized
+        + InternalIrcMessageIncoming
+        + InternalIrcMessageOutgoing;
+
+    type Error: Debug;
+
+    /// Construct an instance of the codec based on the given character encoding.
+    fn try_new(char_encoding: impl AsRef<str>) -> Result<Self, <Self as MessageCodec>::Error>;
+
+    /// Sanitizes the input string by cutting up to (and including) the first occurence of a line
+    /// terminiating phrase (`\r\n`, `\r`, or `\n`). This is used in sending messages through the
+    /// codec to prevent the injection of additional commands.
+    fn sanitize(mut data: String) -> String {
+        // n.b. ordering matters here to prefer "\r\n" over "\r"
+        if let Some((pos, len)) = ["\r\n", "\r", "\n"]
+            .iter()
+            .flat_map(|needle| data.find(needle).map(|pos| (pos, needle.len())))
+            .min_by_key(|&(pos, _)| pos)
+        {
+            data.truncate(pos + len);
+        }
+        data
+    }
+}
+
+/// An message type that supports decoding the commands necessary to maintain communication with a basic IRC server.
+pub trait InternalIrcMessageIncoming: Sized {
+    // Override if you want to be able to join channels:
+
+    /// Whether or not this message is a `RPL_ENDOFMOTD` response.
+    fn is_end_of_motd(&self) -> bool {
+        false
+    }
+
+    /// Whether or not this message is a `ERR_NOMOTD` response.
+    fn is_err_nomotd(&self) -> bool {
+        false
+    }
+
+    // Override if you don't want to time out after a few minutes:
+
+    /// Whether or not this message is a `PONG` message.
+    fn is_pong(&self) -> bool {
+        false
+    }
+
+    /// If this message is a `PING` message, this returns the payload.
+    fn as_ping<'a>(&'a self) -> Option<&'a str> {
+        None
+    }
+
+    // Override if you want to be able to know when you've been kicked out of a server:
+
+    /// Whether or not this message is a `QUIT` message.
+    fn is_quit(&self) -> bool {
+        false
+    }
+}
+
+/// An message type that supports encoding enough message types to maintain communication with an IRC server.
+/// All functions can be deduced automatically as long as `new_raw` is implemented.
+pub trait InternalIrcMessageOutgoing: Sized {
+    /// Create a message from scratch.
+    fn new_raw(command: String, arguments: Vec<String>) -> Self;
+
+    // Basic functionality
+    // Encode message types that are absolutely necessary for the communication even with basic IRC servers.
+
+    /// Create a `PING` message.
+    fn new_ping(server: String) -> Self {
+        Self::new_raw("PING".to_owned(), vec![server])
+    }
+
+    /// Create a `PONG` message.
+    fn new_pong(daemon: String) -> Self {
+        Self::new_raw("PONG".to_owned(), vec![daemon])
+    }
+
+    /// Create a `CAP END` message (end of capabilities request).
+    fn new_cap_end() -> Self {
+        Self::new_raw("CAP".to_owned(), vec!["END".to_owned()])
+    }
+
+    /// Create a `NICK` message.
+    fn new_nick(nick: String) -> Self {
+        Self::new_raw("NICK".to_owned(), vec![nick])
+    }
+
+    /// Create a `USER` message. The user mode will be set to `0`.
+    fn new_user(username: String, realname: String) -> Self {
+        Self::new_raw(
+            "USER".to_owned(),
+            vec![username, "0".to_owned(), "*".to_owned(), realname],
+        )
+    }
+
+    /// Create a `JOIN` message for channels that do not require authentification.
+    fn new_join(channel_list: String) -> Self {
+        Self::new_raw("JOIN".to_owned(), vec![channel_list])
+    }
+
+    /// Create a `PART` message.
+    fn new_part(channel_list: String) -> Self {
+        Self::new_raw("PART".to_owned(), vec![channel_list])
+    }
+
+    /// Create a `QUIT` message.
+    fn new_quit(message: String) -> Self {
+        Self::new_raw("QUIT".to_owned(), vec![message])
+    }
+
+    // User Authentification
+    // Encode message types necessary to authenticate users.
+
+    /// Create a `PASS` message.
+    fn new_pass(password: String) -> Self {
+        Self::new_raw("PASS".to_owned(), vec![password])
+    }
+
+    /// Create a `JOIN` message for channels that require authentification.
+    fn new_authenticated_join(channel_list: String, pass_list: String) -> Self {
+        Self::new_raw("JOIN".to_owned(), vec![channel_list, pass_list])
+    }
+
+    /// Create a `NICKSERV` message.
+    fn new_nickserv(commands: Vec<String>) -> Self {
+        Self::new_raw("NICKSERV".to_owned(), commands)
+    }
+}

--- a/irc-interface/src/line.rs
+++ b/irc-interface/src/line.rs
@@ -56,6 +56,12 @@ where
     }
 }
 
+impl<Msg> Debug for LineCodec<Msg> {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "LineCodec")
+    }
+}
+
 impl<Msg> Encoder<Msg> for LineCodec<Msg>
 where
     Msg: LineMessage,

--- a/irc-interface/src/line.rs
+++ b/irc-interface/src/line.rs
@@ -1,0 +1,166 @@
+//! Abstract structure for line-based codecs.
+//! Most codecs will be based on parsing messages line-by-line. This trait simplifies implementing such codecs.
+//! Instead of having to implement the [`Decoder`] and [`Encoder`] traits manually, it suffices to implement [`LineCodec`].
+
+use crate::{
+    Decoder, Encoder, InternalIrcMessageIncoming, InternalIrcMessageOutgoing, MessageCodec,
+};
+use bytes::BytesMut;
+use encoding::{label::encoding_from_whatwg_label, DecoderTrap, EncoderTrap, EncodingRef};
+use std::{
+    fmt::{Debug, Display},
+    io,
+    str::FromStr,
+};
+
+/// Split received data into lines using [`LineCodecInner`] and and then run parsing functions as defined in [`LineCodec`]'s [`Encoder`] and [`Decoder`] implementations.
+/// They refer the message to [`Display::to_string`] and [`FromStr::try_from`] methods.
+pub struct LineCodec<Msg> {
+    inner: LineSplitter,
+    _phantom: std::marker::PhantomData<Msg>,
+}
+
+/// Splits received data into lines, each of which are encoded as [`String`].
+pub struct LineSplitter {
+    encoding: EncodingRef,
+    next_index: usize,
+}
+
+/// A message that can be parsed using a line parser.
+pub trait LineMessage:
+    Display
+    + FromStr
+    + InternalIrcMessageIncoming
+    + InternalIrcMessageOutgoing
+    + Debug
+    + Clone
+    + Unpin
+    + Sized
+{
+    type Error: From<io::Error> + From<<Self as FromStr>::Err> + Debug;
+}
+
+impl<Msg> MessageCodec for LineCodec<Msg>
+where
+    Msg: LineMessage,
+{
+    type MsgItem = Msg;
+    type Error = <Msg as LineMessage>::Error;
+
+    /// Creates a new instance of IrcCodec wrapping a LineCodec with the specific encoding.
+    fn try_new(label: impl AsRef<str>) -> Result<Self, <Self as MessageCodec>::Error> {
+        Ok(LineSplitter::try_new(label).map(|codec| Self {
+            inner: codec,
+            _phantom: std::marker::PhantomData,
+        })?)
+    }
+}
+
+impl<Msg> Encoder<Msg> for LineCodec<Msg>
+where
+    Msg: LineMessage,
+{
+    type Error = <Msg as LineMessage>::Error;
+
+    fn encode(
+        &mut self,
+        msg: Msg,
+        dst: &mut BytesMut,
+    ) -> Result<(), <Self as Encoder<Msg>>::Error> {
+        Ok(self
+            .inner
+            .encode(<Self as MessageCodec>::sanitize(msg.to_string()), dst)?)
+    }
+}
+
+impl<Msg> Decoder for LineCodec<Msg>
+where
+    Msg: LineMessage,
+{
+    type Error = <Msg as LineMessage>::Error;
+    type Item = Msg;
+
+    fn decode(&mut self, src: &mut BytesMut) -> Result<Option<Msg>, <Self as Decoder>::Error> {
+        if let Some(msg) = self.inner.decode(src)? {
+            Ok(Some(msg.parse::<Msg>()?))
+        } else {
+            Ok(None)
+        }
+    }
+}
+
+impl LineSplitter {
+    /// Creates a new instance from the specified encoding.
+    fn try_new(label: impl AsRef<str>) -> Result<Self, io::Error> {
+        encoding_from_whatwg_label(label.as_ref())
+            .map(|enc| LineSplitter {
+                encoding: enc,
+                next_index: 0,
+            })
+            .ok_or_else(|| {
+                io::Error::new(
+                    io::ErrorKind::InvalidInput,
+                    &format!("Attempted to use unknown codec {}.", label.as_ref())[..],
+                )
+                .into()
+            })
+    }
+}
+
+impl Encoder<String> for LineSplitter {
+    type Error = io::Error;
+
+    fn encode(
+        &mut self,
+        msg: String,
+        dst: &mut BytesMut,
+    ) -> Result<(), <Self as Encoder<String>>::Error> {
+        // Encode the message using the codec's encoding.
+        let data: Result<Vec<u8>, io::Error> = self
+            .encoding
+            .encode(&msg, EncoderTrap::Replace)
+            .map_err(|data| {
+                io::Error::new(
+                    io::ErrorKind::InvalidInput,
+                    &format!("Failed to encode {} as {}.", data, self.encoding.name())[..],
+                )
+            });
+
+        // Write the encoded message to the output buffer.
+        dst.extend(&data?);
+
+        Ok(())
+    }
+}
+
+impl Decoder for LineSplitter {
+    type Item = String;
+    type Error = io::Error;
+
+    fn decode(
+        &mut self,
+        src: &mut BytesMut,
+    ) -> Result<Option<<Self as Decoder>::Item>, <Self as Decoder>::Error> {
+        if let Some(offset) = src[self.next_index..].iter().position(|b| *b == b'\n') {
+            // Remove the next frame from the buffer.
+            let line = src.split_to(self.next_index + offset + 1);
+
+            // Set the search start index back to 0 since we found a newline.
+            self.next_index = 0;
+
+            // Decode the line using the codec's encoding.
+            match self.encoding.decode(line.as_ref(), DecoderTrap::Replace) {
+                Ok(data) => Ok(Some(data)),
+                Err(data) => Err(io::Error::new(
+                    io::ErrorKind::InvalidInput,
+                    &format!("Failed to decode {} as {}.", data, self.encoding.name())[..],
+                )),
+            }
+        } else {
+            // Set the search start index to the current length since we know that none of the
+            // characters we've already looked at are newlines.
+            self.next_index = src.len();
+            Ok(None)
+        }
+    }
+}

--- a/irc-proto/Cargo.toml
+++ b/irc-proto/Cargo.toml
@@ -15,11 +15,11 @@ travis-ci = { repository = "aatxe/irc" }
 
 [features]
 default = ["bytes", "tokio", "tokio-util"]
+tokio-util = []
 
 [dependencies]
 encoding = "0.2.0"
 thiserror = "1.0.0"
-
+irc-interface = { version = "0.0.1", path = "../irc-interface" }
 bytes = { version = "1.0.0", optional = true }
 tokio = { version = "1.0.0", optional = true }
-tokio-util = { version = "0.6.0", features = ["codec"], optional = true }

--- a/irc-proto/src/irc.rs
+++ b/irc-proto/src/irc.rs
@@ -1,6 +1,6 @@
 //! Implementation of IRC codec for Tokio.
 use bytes::BytesMut;
-use tokio_util::codec::{Decoder, Encoder};
+use irc_interface::{Decoder, Encoder};
 
 use crate::error;
 use crate::line::LineCodec;

--- a/irc-proto/src/irc.rs
+++ b/irc-proto/src/irc.rs
@@ -1,4 +1,6 @@
 //! Implementation of IRC codec for Tokio.
+use std::fmt::Debug;
+
 use bytes::BytesMut;
 use irc_interface::{Decoder, Encoder};
 
@@ -49,5 +51,11 @@ impl Encoder<Message> for IrcCodec {
 
     fn encode(&mut self, msg: Message, dst: &mut BytesMut) -> error::Result<()> {
         self.inner.encode(IrcCodec::sanitize(msg.to_string()), dst)
+    }
+}
+
+impl Debug for IrcCodec {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "IrcCodec")
     }
 }

--- a/irc-proto/src/lib.rs
+++ b/irc-proto/src/lib.rs
@@ -16,6 +16,8 @@ pub mod mode;
 pub mod prefix;
 pub mod response;
 
+use irc_interface::{InternalIrcMessageIncoming, InternalIrcMessageOutgoing, MessageCodec};
+
 pub use self::caps::{Capability, NegotiationVersion};
 pub use self::chan::ChannelExt;
 pub use self::colors::FormattedStringExt;
@@ -26,3 +28,98 @@ pub use self::message::Message;
 pub use self::mode::{ChannelMode, Mode, UserMode};
 pub use self::prefix::Prefix;
 pub use self::response::Response;
+
+#[cfg(feature = "tokio")]
+impl MessageCodec for IrcCodec {
+    type MsgItem = Message;
+    type Error = error::ProtocolError;
+
+    fn try_new(char_encoding: impl AsRef<str>) -> Result<Self, <Self as MessageCodec>::Error> {
+        Self::new(char_encoding.as_ref())
+    }
+}
+
+#[cfg(feature = "tokio")]
+impl InternalIrcMessageOutgoing for Message {
+    fn new_raw(command: String, arguments: Vec<String>) -> Self {
+        Command::Raw(command, arguments).into()
+    }
+
+    fn new_quit(message: String) -> Self {
+        const DEFAULT_QUIT_MESSAGE: &str = "Powered by Rust.";
+        Command::QUIT(Some(if message.is_empty() {
+            DEFAULT_QUIT_MESSAGE.to_string()
+        } else {
+            message
+        }))
+        .into()
+    }
+
+    // Implementations below aren't strictly necessary since they should be equal to the default implementations.
+    // However, they are included here to make sure that no new bugs are introduced.
+    fn new_ping(server: String) -> Self {
+        Command::PING(server, None).into()
+    }
+
+    fn new_pong(daemon: String) -> Self {
+        Command::PONG(daemon, None).into()
+    }
+
+    fn new_cap_end() -> Self {
+        Command::CAP(None, CapSubCommand::END, None, None).into()
+    }
+
+    fn new_nick(nick: String) -> Self {
+        Command::NICK(nick).into()
+    }
+
+    fn new_user(username: String, realname: String) -> Self {
+        Command::USER(username, "0".to_owned(), realname).into()
+    }
+
+    fn new_join(channel_list: String) -> Self {
+        Command::JOIN(channel_list, None, None).into()
+    }
+
+    fn new_part(channel_list: String) -> Self {
+        Command::PART(channel_list, None).into()
+    }
+
+    fn new_pass(password: String) -> Self {
+        Command::PASS(password).into()
+    }
+
+    fn new_authenticated_join(channel_list: String, pass_list: String) -> Self {
+        Command::JOIN(channel_list, Some(pass_list), None).into()
+    }
+
+    fn new_nickserv(commands: Vec<String>) -> Self {
+        Command::NICKSERV(commands).into()
+    }
+}
+
+#[cfg(feature = "tokio")]
+impl InternalIrcMessageIncoming for Message {
+    fn is_end_of_motd(&self) -> bool {
+        matches!(self.command, Command::Response(Response::RPL_ENDOFMOTD, _))
+    }
+    fn is_err_nomotd(&self) -> bool {
+        matches!(self.command, Command::Response(Response::ERR_NOMOTD, _))
+    }
+
+    fn is_pong(&self) -> bool {
+        matches!(self.command, Command::PONG(..))
+    }
+
+    fn is_quit(&self) -> bool {
+        matches!(self.command, Command::QUIT(..))
+    }
+
+    fn as_ping<'a>(&'a self) -> Option<&'a str> {
+        if let Command::PING(ref payload, _) = self.command {
+            Some(payload.as_ref())
+        } else {
+            None
+        }
+    }
+}

--- a/irc-proto/src/line.rs
+++ b/irc-proto/src/line.rs
@@ -5,7 +5,7 @@ use std::io;
 use bytes::BytesMut;
 use encoding::label::encoding_from_whatwg_label;
 use encoding::{DecoderTrap, EncoderTrap, EncodingRef};
-use tokio_util::codec::{Decoder, Encoder};
+use irc_interface::{Decoder, Encoder};
 
 use crate::error;
 

--- a/no-parse-codec/Cargo.toml
+++ b/no-parse-codec/Cargo.toml
@@ -1,0 +1,16 @@
+[package]
+name = "no-parse-codec"
+version = "0.0.1"
+edition = "2021"
+
+# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
+
+[dependencies]
+irc-interface = { path = "../irc-interface" }
+once_cell = "1.13.0"
+regex = "1.6.0"
+
+[dev-dependencies]
+irc = { path = "../", default-features = false, features = ["codec-tests"] }
+anyhow = "1.0.0"
+tokio = { version = "1.0.0", features = ["rt", "rt-multi-thread", "macros", "net", "time"] }

--- a/no-parse-codec/Cargo.toml
+++ b/no-parse-codec/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "no-parse-codec"
-version = "0.0.3"
+version = "0.0.4"
 edition = "2021"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html

--- a/no-parse-codec/Cargo.toml
+++ b/no-parse-codec/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "no-parse-codec"
-version = "0.0.1"
+version = "0.0.3"
 edition = "2021"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html

--- a/no-parse-codec/Cargo.toml
+++ b/no-parse-codec/Cargo.toml
@@ -14,3 +14,5 @@ regex = "1.6.0"
 irc = { path = "../", default-features = false, features = ["codec-tests"] }
 anyhow = "1.0.0"
 tokio = { version = "1.0.0", features = ["rt", "rt-multi-thread", "macros", "net", "time"] }
+env_logger = "0.9.1"
+futures-util = "0.3.25"

--- a/no-parse-codec/src/lib.rs
+++ b/no-parse-codec/src/lib.rs
@@ -56,6 +56,9 @@ mod regex {
 
     pub(super) static PONG: Lazy<Regex> = Lazy::new(|| Regex::new(r"^(:[^ ]* )?PONG").unwrap());
 
+    pub(super) static PING: Lazy<Regex> =
+        Lazy::new(|| Regex::new(r"^(:[^ ]* )?PING (?P<token>\S+)").unwrap());
+
     pub(super) static QUIT: Lazy<Regex> = Lazy::new(|| Regex::new(r"^(:[^ ]* )?QUIT").unwrap());
 }
 
@@ -76,7 +79,12 @@ impl InternalIrcMessageIncoming for UnparsedMessage {
     }
 
     fn as_ping<'a>(&'a self) -> Option<&'a str> {
-        None
+        regex::PING.captures(&self.0).map(|captures| {
+            captures
+                .name("token")
+                .unwrap_or_else(|| unreachable!())
+                .as_str()
+        })
     }
 
     fn is_quit(&self) -> bool {

--- a/no-parse-codec/src/lib.rs
+++ b/no-parse-codec/src/lib.rs
@@ -1,0 +1,120 @@
+use std::{fmt::Display, io, str::FromStr};
+
+use irc_interface::{
+    line::LineMessage, InternalIrcMessageIncoming, InternalIrcMessageOutgoing, LineCodec,
+};
+
+/// A minimal message codec that makes the irc client functional without actually parsing the messages.
+pub type NoParseCodec = LineCodec<UnparsedMessage>;
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct UnparsedMessage(String);
+
+impl Display for UnparsedMessage {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "{}", self.0)
+    }
+}
+
+impl FromStr for UnparsedMessage {
+    type Err = io::Error;
+
+    fn from_str(s: &str) -> Result<Self, io::Error> {
+        Result::<Self, <Self as FromStr>::Err>::Ok(UnparsedMessage(s.to_string()))
+    }
+}
+
+impl LineMessage for UnparsedMessage {
+    type Error = io::Error;
+}
+
+impl InternalIrcMessageOutgoing for UnparsedMessage {
+    fn new_raw(command: String, arguments: Vec<String>) -> Self {
+        UnparsedMessage(format!("{} {}\r\n", command, arguments.join(" ")))
+    }
+}
+
+mod regex {
+    //! initialize lazily evaluated regexes
+    use once_cell::sync::Lazy;
+    use regex::Regex;
+
+    pub(super) static END_OF_MOTD: Lazy<Regex> =
+        Lazy::new(|| Regex::new(r"^(:[^ ]* )?376").unwrap());
+
+    pub(super) static ERR_NO_MOTD: Lazy<Regex> =
+        Lazy::new(|| Regex::new(r"^(:[^ ]* )?422").unwrap());
+
+    pub(super) static PONG: Lazy<Regex> = Lazy::new(|| Regex::new(r"^(:[^ ]* )?PONG").unwrap());
+
+    pub(super) static QUIT: Lazy<Regex> = Lazy::new(|| Regex::new(r"^(:[^ ]* )?QUIT").unwrap());
+}
+
+// TODO: I could make this more efficient by adding a slice to the structure which only refers to the part of the string that contains the message (without prefix)
+
+impl InternalIrcMessageIncoming for UnparsedMessage {
+    fn is_end_of_motd(&self) -> bool {
+        regex::END_OF_MOTD.is_match(&self.0)
+    }
+
+    fn is_err_nomotd(&self) -> bool {
+        regex::ERR_NO_MOTD.is_match(&self.0)
+    }
+
+    // TODO: Write test for ping/pong
+    fn is_pong(&self) -> bool {
+        regex::PONG.is_match(&self.0)
+    }
+
+    fn as_ping<'a>(&'a self) -> Option<&'a str> {
+        None
+    }
+
+    fn is_quit(&self) -> bool {
+        regex::QUIT.is_match(&self.0)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+
+    // WARNING: VS Code shows errors here, because it falsely assumes that the irc crate's `essential` feature is activated
+
+    use crate::NoParseCodec;
+    use anyhow::Result;
+    use irc::client::codec_tests::TestSuite;
+
+    #[tokio::test]
+    async fn handle_end_motd() -> Result<()> {
+        TestSuite::<NoParseCodec>::handle_end_motd().await
+    }
+
+    #[tokio::test]
+    async fn handle_end_motd_with_nick_password() -> Result<()> {
+        TestSuite::<NoParseCodec>::handle_end_motd_with_nick_password().await
+    }
+    #[tokio::test]
+    async fn identify() -> Result<()> {
+        TestSuite::<NoParseCodec>::identify().await
+    }
+
+    #[tokio::test]
+    async fn identify_with_password() -> Result<()> {
+        TestSuite::<NoParseCodec>::identify_with_password().await
+    }
+
+    #[tokio::test]
+    async fn send_pong() -> Result<()> {
+        TestSuite::<NoParseCodec>::send_pong().await
+    }
+
+    #[tokio::test]
+    async fn send_join() -> Result<()> {
+        TestSuite::<NoParseCodec>::send_join().await
+    }
+
+    #[tokio::test]
+    async fn send_part() -> Result<()> {
+        TestSuite::<NoParseCodec>::send_part().await
+    }
+}

--- a/no-parse-codec/src/lib.rs
+++ b/no-parse-codec/src/lib.rs
@@ -89,7 +89,7 @@ impl InternalIrcMessageIncoming for UnparsedMessage {
         regex::PONG.is_match(&self.0)
     }
 
-    fn as_ping<'a>(&'a self) -> Option<&'a str> {
+    fn as_ping(&self) -> Option<&str> {
         regex::PING.captures(&self.0).map(|captures| {
             captures
                 .name("token")
@@ -105,13 +105,17 @@ impl InternalIrcMessageIncoming for UnparsedMessage {
 
 impl UnparsedMessage {
     /// Parse the capability list in a `CAP * LS` response.
-    pub fn as_cap_ls<'a>(&'a self) -> Option<&'a str> {
+    pub fn as_cap_ls(&self) -> Option<&str> {
         regex::CAP_LS.captures(&self.0).map(|captures| {
             captures
                 .name("capabilities")
                 .unwrap_or_else(|| unreachable!())
                 .as_str()
         })
+    }
+
+    pub fn as_str(&self) -> &str {
+        self.0.as_str()
     }
 }
 

--- a/no-parse-codec/src/lib.rs
+++ b/no-parse-codec/src/lib.rs
@@ -54,20 +54,23 @@ mod regex {
     use regex::Regex;
 
     pub(super) static END_OF_MOTD: Lazy<Regex> =
-        Lazy::new(|| Regex::new(r"^(:[^ ]* )?376").unwrap());
+        Lazy::new(|| Regex::new(r"^(@[\S]* )?(:[\S]* )?376").unwrap());
 
     pub(super) static ERR_NO_MOTD: Lazy<Regex> =
-        Lazy::new(|| Regex::new(r"^(:[^ ]* )?422").unwrap());
+        Lazy::new(|| Regex::new(r"^(@[\S]* )?(:[\S]* )?422").unwrap());
 
-    pub(super) static PONG: Lazy<Regex> = Lazy::new(|| Regex::new(r"^(:[^ ]* )?PONG").unwrap());
+    pub(super) static PONG: Lazy<Regex> =
+        Lazy::new(|| Regex::new(r"^(@[\S]* )?(:[\S]* )?PONG").unwrap());
 
     pub(super) static PING: Lazy<Regex> =
-        Lazy::new(|| Regex::new(r"^(:[^ ]* )?PING (?P<token>\S+)").unwrap());
+        Lazy::new(|| Regex::new(r"^(@[\S]* )?(:[\S]* )?PING (?P<token>\S+)").unwrap());
 
-    pub(super) static QUIT: Lazy<Regex> = Lazy::new(|| Regex::new(r"^(:[^ ]* )?QUIT").unwrap());
+    pub(super) static QUIT: Lazy<Regex> =
+        Lazy::new(|| Regex::new(r"^(@[\S]* )?(:[\S]* )?QUIT").unwrap());
 
-    pub(super) static CAP_LS: Lazy<Regex> =
-        Lazy::new(|| Regex::new(r"^(:[\S]* )?CAP \* LS :(?P<capabilities>.*)(\r\n)?$").unwrap());
+    pub(super) static CAP_LS: Lazy<Regex> = Lazy::new(|| {
+        Regex::new(r"^(@[\S]* )?(:[\S]* )?CAP \* LS :(?P<capabilities>.*)(\r\n)?$").unwrap()
+    });
 }
 
 // TODO: I could make this more efficient by adding a slice to the structure which only refers to the part of the string that contains the message (without prefix)

--- a/no-parse-codec/src/lib.rs
+++ b/no-parse-codec/src/lib.rs
@@ -24,6 +24,15 @@ impl FromStr for UnparsedMessage {
     }
 }
 
+impl<T> From<T> for UnparsedMessage
+where
+    T: Into<String>,
+{
+    fn from(item: T) -> Self {
+        Self(item.into())
+    }
+}
+
 impl LineMessage for UnparsedMessage {
     type Error = io::Error;
 }

--- a/no-parse-codec/src/lib.rs
+++ b/no-parse-codec/src/lib.rs
@@ -20,7 +20,7 @@ impl FromStr for UnparsedMessage {
     type Err = io::Error;
 
     fn from_str(s: &str) -> Result<Self, io::Error> {
-        Result::<Self, <Self as FromStr>::Err>::Ok(UnparsedMessage(s.to_string()))
+        Result::<Self, <Self as FromStr>::Err>::Ok(UnparsedMessage(s.into()))
     }
 }
 
@@ -29,7 +29,12 @@ where
     T: Into<String>,
 {
     fn from(item: T) -> Self {
-        Self(item.into())
+        let item: String = item.into();
+        if item.ends_with("\r\n") {
+            Self(item)
+        } else {
+            Self(format!("{item}\r\n"))
+        }
     }
 }
 

--- a/no-parse-codec/src/lib.rs
+++ b/no-parse-codec/src/lib.rs
@@ -8,7 +8,7 @@ use irc_interface::{
 pub type NoParseCodec = LineCodec<UnparsedMessage>;
 
 #[derive(Debug, Clone, PartialEq, Eq)]
-pub struct UnparsedMessage(String);
+pub struct UnparsedMessage(pub String);
 
 impl Display for UnparsedMessage {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {

--- a/no-parse-codec/tests/no_parse_codec.rs
+++ b/no-parse-codec/tests/no_parse_codec.rs
@@ -2,14 +2,15 @@
 //! This means that messages are received as Strings rather than [`irc_proto::Command`] objects.
 //! This only works if you run it with `--no-default-features`.
 
-// TODO: This should be an integration test for the `no_parse_codec` crate
+#[allow(unused_imports)] // avoid false-positive in next line
+use futures_util::StreamExt;
 
-use futures::prelude::*;
 use irc::client::prelude::*;
 use no_parse_codec::*;
 
-#[tokio::main]
-async fn main() -> irc::error::Result<()> {
+#[tokio::test]
+async fn connect_to_server() -> irc::error::Result<()> {
+    env_logger::init();
     let config = Config {
         nickname: Some("pickles".to_owned()),
         server: Some("chat.freenode.net".to_owned()),
@@ -24,7 +25,10 @@ async fn main() -> irc::error::Result<()> {
 
     while let Some(message) = stream.next().await.transpose()? {
         print!("{}", message);
+        if message.to_string().contains("End of /NAMES list.") {
+            return Ok(());
+        }
     }
 
-    Ok(())
+    panic!("Failed to maintain connection");
 }

--- a/src/client/conn.rs
+++ b/src/client/conn.rs
@@ -95,7 +95,7 @@ where
     pub(crate) async fn new(
         config: &Config,
         tx: UnboundedSender<Codec::MsgItem>,
-    ) -> error::Result<Connection<Codec>> {
+    ) -> error::Result<Self> {
         if config.use_mock_connection() {
             log::info!("Connecting via mock to {}.", config.server()?);
             return Ok(Connection::Mock(Logged::wrap(

--- a/src/client/conn.rs
+++ b/src/client/conn.rs
@@ -280,7 +280,7 @@ where
 
         let stream = Self::new_stream(config).await?;
         let stream = connector.connect(domain, stream).await?;
-        let framed = Framed::new(stream, IrcCodec::new(config.encoding())?);
+        let framed = Framed::new(stream, Codec::try_new(config.encoding())?);
 
         Ok(Transport::new(&config, framed, tx))
     }

--- a/src/client/conn.rs
+++ b/src/client/conn.rs
@@ -8,7 +8,7 @@ use std::{
 };
 use tokio::net::TcpStream;
 use tokio::sync::mpsc::UnboundedSender;
-use tokio_util::codec::Framed;
+use tokio_util::codec::{Decoder, Encoder, Framed};
 
 #[cfg(feature = "proxy")]
 use tokio_socks::tcp::Socks5Stream;
@@ -50,22 +50,29 @@ use crate::{
         transport::{LogView, Logged, Transport},
     },
     error,
-    proto::{IrcCodec, Message},
 };
+
+use super::data::codec::MessageCodec;
 
 /// An IRC connection used internally by `IrcServer`.
 #[pin_project(project = ConnectionProj)]
-pub enum Connection {
+pub enum Connection<Codec>
+where
+    Codec: MessageCodec,
+{
     #[doc(hidden)]
-    Unsecured(#[pin] Transport<TcpStream>),
+    Unsecured(#[pin] Transport<TcpStream, Codec>),
     #[doc(hidden)]
     #[cfg(any(feature = "tls-native", feature = "tls-rust"))]
-    Secured(#[pin] Transport<TlsStream<TcpStream>>),
+    Secured(#[pin] Transport<TlsStream<TcpStream>, Codec>),
     #[doc(hidden)]
-    Mock(#[pin] Logged<MockStream>),
+    Mock(#[pin] Logged<MockStream, Codec>),
 }
 
-impl fmt::Debug for Connection {
+impl<Codec> fmt::Debug for Connection<Codec>
+where
+    Codec: MessageCodec,
+{
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(
             f,
@@ -80,12 +87,15 @@ impl fmt::Debug for Connection {
     }
 }
 
-impl Connection {
+impl<Codec> Connection<Codec>
+where
+    Codec: MessageCodec,
+{
     /// Creates a new `Connection` using the specified `Config`
     pub(crate) async fn new(
         config: &Config,
-        tx: UnboundedSender<Message>,
-    ) -> error::Result<Connection> {
+        tx: UnboundedSender<Codec::MsgItem>,
+    ) -> error::Result<Connection<Codec>> {
         if config.use_mock_connection() {
             log::info!("Connecting via mock to {}.", config.server()?);
             return Ok(Connection::Mock(Logged::wrap(
@@ -149,10 +159,10 @@ impl Connection {
 
     async fn new_unsecured_transport(
         config: &Config,
-        tx: UnboundedSender<Message>,
-    ) -> error::Result<Transport<TcpStream>> {
+        tx: UnboundedSender<Codec::MsgItem>,
+    ) -> error::Result<Transport<TcpStream, Codec>> {
         let stream = Self::new_stream(config).await?;
-        let framed = Framed::new(stream, IrcCodec::new(config.encoding())?);
+        let framed = Framed::new(stream, Codec::try_new(config.encoding())?);
 
         Ok(Transport::new(&config, framed, tx))
     }
@@ -160,8 +170,8 @@ impl Connection {
     #[cfg(feature = "tls-native")]
     async fn new_secured_transport(
         config: &Config,
-        tx: UnboundedSender<Message>,
-    ) -> error::Result<Transport<TlsStream<TcpStream>>> {
+        tx: UnboundedSender<Codec::MsgItem>,
+    ) -> error::Result<Transport<TlsStream<TcpStream>, Codec>> {
         let mut builder = TlsConnector::builder();
 
         if let Some(cert_path) = config.cert_path() {
@@ -207,7 +217,7 @@ impl Connection {
 
         let stream = Self::new_stream(config).await?;
         let stream = connector.connect(domain, stream).await?;
-        let framed = Framed::new(stream, IrcCodec::new(config.encoding())?);
+        let framed = Framed::new(stream, Codec::try_new(config.encoding())?);
 
         Ok(Transport::new(&config, framed, tx))
     }
@@ -215,8 +225,8 @@ impl Connection {
     #[cfg(feature = "tls-rust")]
     async fn new_secured_transport(
         config: &Config,
-        tx: UnboundedSender<Message>,
-    ) -> error::Result<Transport<TlsStream<TcpStream>>> {
+        tx: UnboundedSender<Codec::MsgItem>,
+    ) -> error::Result<Transport<TlsStream<TcpStream>>, Codec> {
         let mut builder = ClientConfig::default();
         builder
             .root_store
@@ -277,8 +287,8 @@ impl Connection {
 
     async fn new_mocked_transport(
         config: &Config,
-        tx: UnboundedSender<Message>,
-    ) -> error::Result<Transport<MockStream>> {
+        tx: UnboundedSender<Codec::MsgItem>,
+    ) -> error::Result<Transport<MockStream, Codec>> {
         use encoding::{label::encoding_from_whatwg_label, EncoderTrap};
 
         let encoding = encoding_from_whatwg_label(config.encoding()).ok_or_else(|| {
@@ -296,14 +306,14 @@ impl Connection {
             })?;
 
         let stream = MockStream::new(&initial);
-        let framed = Framed::new(stream, IrcCodec::new(config.encoding())?);
+        let framed = Framed::new(stream, Codec::try_new(config.encoding())?);
 
         Ok(Transport::new(&config, framed, tx))
     }
 
     /// Gets a view of the internal logging if and only if this connection is using a mock stream.
     /// Otherwise, this will always return `None`. This is used for unit testing.
-    pub fn log_view(&self) -> Option<LogView> {
+    pub fn log_view(&self) -> Option<LogView<Codec::MsgItem>> {
         match *self {
             Connection::Mock(ref inner) => Some(inner.view()),
             _ => None,
@@ -311,8 +321,12 @@ impl Connection {
     }
 }
 
-impl Stream for Connection {
-    type Item = error::Result<Message>;
+impl<Codec> Stream for Connection<Codec>
+where
+    Codec: MessageCodec,
+    error::Error: From<<Codec as Decoder>::Error>,
+{
+    type Item = error::Result<Codec::MsgItem>;
 
     fn poll_next(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Option<Self::Item>> {
         match self.project() {
@@ -324,7 +338,11 @@ impl Stream for Connection {
     }
 }
 
-impl Sink<Message> for Connection {
+impl<Codec> Sink<Codec::MsgItem> for Connection<Codec>
+where
+    Codec: MessageCodec,
+    error::Error: From<<Codec as Encoder<Codec::MsgItem>>::Error>,
+{
     type Error = error::Error;
 
     fn poll_ready(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Result<(), Self::Error>> {
@@ -336,7 +354,7 @@ impl Sink<Message> for Connection {
         }
     }
 
-    fn start_send(self: Pin<&mut Self>, item: Message) -> Result<(), Self::Error> {
+    fn start_send(self: Pin<&mut Self>, item: Codec::MsgItem) -> Result<(), Self::Error> {
         match self.project() {
             ConnectionProj::Unsecured(inner) => inner.start_send(item),
             #[cfg(any(feature = "tls-native", feature = "tls-rust"))]

--- a/src/client/conn.rs
+++ b/src/client/conn.rs
@@ -52,11 +52,11 @@ use crate::{
     error,
 };
 
-use super::data::codec::MessageCodec;
+use super::{data::codec::MessageCodec, DefaultCodec};
 
 /// An IRC connection used internally by `IrcServer`.
 #[pin_project(project = ConnectionProj)]
-pub enum Connection<Codec>
+pub enum Connection<Codec = DefaultCodec>
 where
     Codec: MessageCodec,
 {

--- a/src/client/data/codec.rs
+++ b/src/client/data/codec.rs
@@ -1,266 +1,35 @@
-//! A trait that describes a codec that can be used to encode or decode IRC messages.
-//! At the moment, this is just a wrapper around [`tokio_util::codec::Decoder`] and [`tokio_util::codec::Encoder`].
-
-use irc_proto::{error::ProtocolError, CapSubCommand, Command, IrcCodec, Response};
-use std::fmt::{Debug, Display};
-
-pub use tokio_util::codec::{Decoder, Encoder};
-
-/// A codec that can be used to encode or decode IRC messages.
-pub trait MessageCodec:
-    Decoder<Item = <Self as MessageCodec>::MsgItem> + Encoder<<Self as MessageCodec>::MsgItem> + Sized
+//! If the `essentials` feature is activated, we want the irc-interface trait to imply [`From<irc_proto::Command>`], so we wrap it into a trait of the same name.
+//! If `essentials` is not activated, we just re-import the trait.
+#[cfg(feature = "essentials")]
+/// Helper trait to feature gate the [`From<crate::proto::Command>`] dependency (which is currently required anything other than barebones mode).
+pub trait InternalIrcMessageOutgoing:
+    irc_interface::InternalIrcMessageOutgoing + From<crate::proto::Command>
 {
-    /// The type of the message that this codec expects for messages that we want to send.
-    type MsgItem: Display
-        + Debug
-        + Clone
-        + Unpin
-        + Sized
-        + InternalIrcMessageIncoming
-        + InternalIrcMessageOutgoing;
-
-    /// Construct an instance of the codec based on the given character encoding.
-    fn try_new(char_encoding: impl AsRef<str>) -> Result<Self, ProtocolError>;
-
-    /// Sanitizes the input string by cutting up to (and including) the first occurence of a line
-    /// terminiating phrase (`\r\n`, `\r`, or `\n`). This is used in sending messages through the
-    /// codec to prevent the injection of additional commands.
-    fn sanitize(mut data: String) -> String {
-        // n.b. ordering matters here to prefer "\r\n" over "\r"
-        if let Some((pos, len)) = ["\r\n", "\r", "\n"]
-            .iter()
-            .flat_map(|needle| data.find(needle).map(|pos| (pos, needle.len())))
-            .min_by_key(|&(pos, _)| pos)
-        {
-            data.truncate(pos + len);
-        }
-        data
-    }
 }
 
 #[cfg(feature = "essentials")]
-/// Helper trait to feature gate the [`From<crate::proto::Command>`] dependency (which is currently required anything other than barebones mode).
-pub trait InternalIrcMessageOutgoingBase: From<crate::proto::Command> {}
-
-#[cfg(feature = "essentials")]
-impl<T> InternalIrcMessageOutgoingBase for T where T: From<crate::proto::Command> {}
+impl<T> InternalIrcMessageOutgoing for T where
+    T: From<crate::proto::Command> + irc_interface::InternalIrcMessageOutgoing
+{
+}
 
 #[cfg(not(feature = "essentials"))]
 /// Helper trait to feature gate the [`From<crate::proto::Command>`] dependency.
-pub trait InternalIrcMessageOutgoingBase {}
-
-#[cfg(not(feature = "essentials"))]
-impl<T> InternalIrcMessageOutgoingBase for T {}
+pub(crate) use irc_interface::InternalIrcMessageOutgoing;
 
 #[cfg(feature = "essentials")]
 /// Helper trait to feature gate the [`std::borrow::Borrow<crate::proto::Message>`] dependency.
-pub trait InternalIrcMessageIncomingBase: std::borrow::Borrow<crate::proto::Message> {}
+pub trait InternalIrcMessageIncoming:
+    std::borrow::Borrow<crate::proto::Message> + irc_interface::InternalIrcMessageIncoming
+{
+}
 
 #[cfg(feature = "essentials")]
-impl<T> InternalIrcMessageIncomingBase for T where T: std::borrow::Borrow<crate::proto::Message> {}
+impl<T> InternalIrcMessageIncoming for T where
+    T: std::borrow::Borrow<crate::proto::Message> + irc_interface::InternalIrcMessageIncoming
+{
+}
 
 #[cfg(not(feature = "essentials"))]
 /// Helper trait to feature gate the [`std::borrow::Borrow<crate::proto::Message>`] dependency.
-pub trait InternalIrcMessageIncomingBase {}
-
-#[cfg(not(feature = "essentials"))]
-impl<T> InternalIrcMessageIncomingBase for T {}
-
-/// An message type that supports decoding the commands necessary to maintain communication with a basic IRC server.
-pub trait InternalIrcMessageIncoming: InternalIrcMessageIncomingBase {
-    // Override if you want to be able to join channels:
-
-    /// Whether or not this message is a `RPL_ENDOFMOTD` response.
-    fn is_end_of_motd(&self) -> bool {
-        false
-    }
-
-    /// Whether or not this message is a `ERR_NOMOTD` response.
-    fn is_err_nomotd(&self) -> bool {
-        false
-    }
-
-    // Override if you don't want to time out after a few minutes:
-
-    /// Whether or not this message is a `PONG` message.
-    fn is_pong(&self) -> bool {
-        false
-    }
-
-    /// If this message is a `PING` message, this returns the payload.
-    fn as_ping<'a>(&'a self) -> Option<&'a str> {
-        None
-    }
-
-    // Override if you want to be able to know when you've been kicked out of a server:
-
-    /// Whether or not this message is a `QUIT` message.
-    fn is_quit(&self) -> bool {
-        false
-    }
-}
-
-/// An message type that supports encoding enough message types to maintain communication with an IRC server.
-/// All functions can be deduced automatically as long as `new_raw` is implemented.
-pub trait InternalIrcMessageOutgoing: InternalIrcMessageOutgoingBase {
-    /// Create a message from scratch.
-    fn new_raw(command: String, arguments: Vec<String>) -> Self;
-
-    // Basic functionality
-    // Encode message types that are absolutely necessary for the communication even with basic IRC servers.
-
-    /// Create a `PING` message.
-    fn new_ping(server: String) -> Self {
-        Self::new_raw("PING".to_owned(), vec![server])
-    }
-
-    /// Create a `PONG` message.
-    fn new_pong(daemon: String) -> Self {
-        Self::new_raw("PONG".to_owned(), vec![daemon])
-    }
-
-    /// Create a `CAP END` message (end of capabilities request).
-    fn new_cap_end() -> Self {
-        Self::new_raw("CAP".to_owned(), vec!["END".to_owned()])
-    }
-
-    /// Create a `NICK` message.
-    fn new_nick(nick: String) -> Self {
-        Self::new_raw("NICK".to_owned(), vec![nick])
-    }
-
-    /// Create a `USER` message. The user mode will be set to `0`.
-    fn new_user(username: String, realname: String) -> Self {
-        Self::new_raw(
-            "USER".to_owned(),
-            vec![username, "0".to_owned(), "*".to_owned(), realname],
-        )
-    }
-
-    /// Create a `JOIN` message for channels that do not require authentification.
-    fn new_join(channel_list: String) -> Self {
-        Self::new_raw("JOIN".to_owned(), vec![channel_list])
-    }
-
-    /// Create a `PART` message.
-    fn new_part(channel_list: String) -> Self {
-        Self::new_raw("PART".to_owned(), vec![channel_list])
-    }
-
-    /// Create a `QUIT` message.
-    fn new_quit(message: String) -> Self {
-        Self::new_raw("QUIT".to_owned(), vec![message])
-    }
-
-    // User Authentification
-    // Encode message types necessary to authenticate users.
-
-    /// Create a `PASS` message.
-    fn new_pass(password: String) -> Self {
-        Self::new_raw("PASS".to_owned(), vec![password])
-    }
-
-    /// Create a `JOIN` message for channels that require authentification.
-    fn new_authenticated_join(channel_list: String, pass_list: String) -> Self {
-        Self::new_raw("JOIN".to_owned(), vec![channel_list, pass_list])
-    }
-
-    /// Create a `NICKSERV` message.
-    fn new_nickserv(commands: Vec<String>) -> Self {
-        Self::new_raw("NICKSERV".to_owned(), commands)
-    }
-}
-
-/// A message type that supports encoding message types necessary to authenticate a password-protected user.
-pub trait OutgoingIrcUserAuthentification {}
-
-impl MessageCodec for IrcCodec {
-    type MsgItem = irc_proto::Message;
-
-    fn try_new(char_encoding: impl AsRef<str>) -> Result<Self, ProtocolError> {
-        Self::new(char_encoding.as_ref())
-    }
-}
-
-impl InternalIrcMessageOutgoing for irc_proto::Message {
-    fn new_raw(command: String, arguments: Vec<String>) -> Self {
-        Command::Raw(command, arguments).into()
-    }
-
-    fn new_quit(message: String) -> Self {
-        const DEFAULT_QUIT_MESSAGE: &str = "Powered by Rust.";
-        Command::QUIT(Some(if message.is_empty() {
-            DEFAULT_QUIT_MESSAGE.to_string()
-        } else {
-            message
-        }))
-        .into()
-    }
-
-    // Implementations below aren't strictly necessary since they should be equal to the default implementations.
-    // However, they are included here to make sure that no new bugs are introduced.
-    fn new_ping(server: String) -> Self {
-        Command::PING(server, None).into()
-    }
-
-    fn new_pong(daemon: String) -> Self {
-        Command::PONG(daemon, None).into()
-    }
-
-    fn new_cap_end() -> Self {
-        Command::CAP(None, CapSubCommand::END, None, None).into()
-    }
-
-    fn new_nick(nick: String) -> Self {
-        Command::NICK(nick).into()
-    }
-
-    fn new_user(username: String, realname: String) -> Self {
-        Command::USER(username, "0".to_owned(), realname).into()
-    }
-
-    fn new_join(channel_list: String) -> Self {
-        Command::JOIN(channel_list, None, None).into()
-    }
-
-    fn new_part(channel_list: String) -> Self {
-        Command::PART(channel_list, None).into()
-    }
-
-    fn new_pass(password: String) -> Self {
-        Command::PASS(password).into()
-    }
-
-    fn new_authenticated_join(channel_list: String, pass_list: String) -> Self {
-        Command::JOIN(channel_list, Some(pass_list), None).into()
-    }
-
-    fn new_nickserv(commands: Vec<String>) -> Self {
-        Command::NICKSERV(commands).into()
-    }
-}
-
-impl InternalIrcMessageIncoming for irc_proto::Message {
-    fn is_end_of_motd(&self) -> bool {
-        matches!(self.command, Command::Response(Response::RPL_ENDOFMOTD, _))
-    }
-    fn is_err_nomotd(&self) -> bool {
-        matches!(self.command, Command::Response(Response::ERR_NOMOTD, _))
-    }
-
-    fn is_pong(&self) -> bool {
-        matches!(self.command, Command::PONG(..))
-    }
-
-    fn is_quit(&self) -> bool {
-        matches!(self.command, Command::QUIT(..))
-    }
-
-    fn as_ping<'a>(&'a self) -> Option<&'a str> {
-        if let Command::PING(ref payload, _) = self.command {
-            Some(payload.as_ref())
-        } else {
-            None
-        }
-    }
-}
+pub(crate) use irc_interface::InternalIrcMessageIncoming;

--- a/src/client/data/codec.rs
+++ b/src/client/data/codec.rs
@@ -1,7 +1,7 @@
 //! A trait that describes a codec that can be used to encode or decode IRC messages.
 //! At the moment, this is just a wrapper around [`tokio_util::codec::Decoder`] and [`tokio_util::codec::Encoder`].
 
-use irc_proto::{error::ProtocolError, Command, IrcCodec, Response};
+use irc_proto::{error::ProtocolError, CapSubCommand, Command, IrcCodec, Response};
 use std::fmt::{Debug, Display};
 
 pub use tokio_util::codec::{Decoder, Encoder};
@@ -11,15 +11,48 @@ pub trait MessageCodec:
     Decoder<Item = <Self as MessageCodec>::MsgItem> + Encoder<<Self as MessageCodec>::MsgItem> + Sized
 {
     /// The type of the message that this codec expects for messages that we want to send.
-    type MsgItem: Display + Debug + Clone + InternalIrcMessageIncoming + InternalIrcMessageOutgoing;
+    type MsgItem: Display
+        + Debug
+        + Clone
+        + Unpin
+        + Sized
+        + InternalIrcMessageIncoming
+        + InternalIrcMessageOutgoing;
 
     /// Construct an instance of the codec based on the given character encoding.
     fn try_new(char_encoding: impl AsRef<str>) -> Result<Self, ProtocolError>;
 }
 
-/// An message type that supports decoding all commands necessary to maintain communication with an IRC server.
-/// For this crate, such messages have to support the `RESPONSE` and `PING` commands.
-pub trait InternalIrcMessageIncoming {
+#[cfg(feature = "essentials")]
+/// Helper trait to feature gate the `From<crate::proto::Command>` dependency.
+pub trait InternalIrcMessageOutgoingBase: From<crate::proto::Command> {}
+
+#[cfg(feature = "essentials")]
+impl<T> InternalIrcMessageOutgoingBase for T where T: From<crate::proto::Command> {}
+
+#[cfg(not(feature = "essentials"))]
+/// Helper trait to feature gate the `From<crate::proto::Command>` dependency.
+pub trait InternalIrcMessageOutgoingBase {}
+
+#[cfg(not(feature = "essentials"))]
+impl<T> InternalIrcMessageOutgoingBase for T {}
+
+#[cfg(feature = "essentials")]
+/// Helper trait to feature gate the `Borrow<crate::proto::Message>` dependency.
+pub trait InternalIrcMessageIncomingBase: std::borrow::Borrow<crate::proto::Message> {}
+
+#[cfg(feature = "essentials")]
+impl<T> InternalIrcMessageIncomingBase for T where T: std::borrow::Borrow<crate::proto::Message> {}
+
+#[cfg(not(feature = "essentials"))]
+/// Helper trait to feature gate the `Borrow<crate::proto::Message>` dependency.
+pub trait InternalIrcMessageIncomingBase {}
+
+#[cfg(not(feature = "essentials"))]
+impl<T> InternalIrcMessageIncomingBase for T {}
+
+/// An message type that supports decoding the commands necessary to maintain communication with a basic IRC server.
+pub trait InternalIrcMessageIncoming: InternalIrcMessageIncomingBase {
     /// Whether or not this message is a `RPL_ENDOFMOTD` response.
     fn is_end_of_motd(&self) -> bool;
 
@@ -29,19 +62,57 @@ pub trait InternalIrcMessageIncoming {
     /// Whether or not this message is a `PONG` message.
     fn is_pong(&self) -> bool;
 
+    /// Whether or not this message is a `QUIT` message.
+    fn is_quit(&self) -> bool;
+
     /// If this message is a `PING` message, this returns the payload.
     fn as_ping(&self) -> Option<String>;
 }
 
-/// An message type that supports encoding all commands necessary to maintain communication with an IRC server.
-/// For this crate, such messages have to support the `PING` and `PONG` commands.
-pub trait InternalIrcMessageOutgoing {
+/// An message type that supports encoding enough message types to maintain communication with an IRC server.
+pub trait InternalIrcMessageOutgoing: InternalIrcMessageOutgoingBase {
+    // Basic functionality
+    // Encode message types that are absolutely necessary for the communication even with basic IRC servers.
+
     /// Create a `PING` message.
-    fn new_ping(server: String, server_fwd: Option<String>) -> Self;
+    fn new_ping(server: String) -> Self;
 
     /// Create a `PONG` message.
-    fn new_pong(daemon: String, daemon_fwd: Option<String>) -> Self;
+    fn new_pong(daemon: String) -> Self;
+
+    /// Create a `CAP END` message (end of capabilities request).
+    fn new_cap_end() -> Self;
+
+    /// Create a `NICK` message.
+    fn new_nick(nick: String) -> Self;
+
+    /// Create a `USER` message. The user mode will be set to `0`.
+    fn new_user(username: String, realname: String) -> Self;
+
+    /// Create a `JOIN` message for channels that do not require authentification.
+    fn new_join(channel_list: String) -> Self;
+
+    /// Create a `PART` message.
+    fn new_part(channel_list: String) -> Self;
+
+    /// Create a `QUIT` message.
+    fn new_quit(message: String) -> Self;
+
+    // User Authentification
+    // Encode message types necessary to authenticate users.
+
+    /// Create a `PASS` message.
+    fn new_pass(password: String) -> Self;
+
+    /// Create a `JOIN` message for channels that require authentification.
+    fn new_authenticated_join(channel_list: String, pass_list: String) -> Self;
+
+    /// Create a `NICKSERV` message.
+    fn new_nickserv(commands: Vec<String>) -> Self;
 }
+
+/// A message type that supports encoding message types necessary to authenticate a password-protected user.
+pub trait OutgoingIrcUserAuthentification {}
 
 impl MessageCodec for IrcCodec {
     type MsgItem = irc_proto::Message;
@@ -52,12 +123,56 @@ impl MessageCodec for IrcCodec {
 }
 
 impl InternalIrcMessageOutgoing for irc_proto::Message {
-    fn new_ping(server: String, server_fwd: Option<String>) -> Self {
-        Command::PING(server, server_fwd).into()
+    fn new_ping(server: String) -> Self {
+        Command::PING(server, None).into()
     }
 
-    fn new_pong(daemon: String, daemon_fwd: Option<String>) -> Self {
-        Command::PONG(daemon, daemon_fwd).into()
+    fn new_pong(daemon: String) -> Self {
+        Command::PONG(daemon, None).into()
+    }
+
+    fn new_cap_end() -> Self {
+        Command::CAP(None, CapSubCommand::END, None, None).into()
+    }
+
+    fn new_nick(nick: String) -> Self {
+        Command::NICK(nick).into()
+    }
+
+    fn new_user(username: String, realname: String) -> Self {
+        Command::USER(username, "0".to_owned(), realname).into()
+    }
+
+    fn new_join(channel_list: String) -> Self {
+        Command::JOIN(channel_list, None, None).into()
+    }
+
+    fn new_part(channel_list: String) -> Self {
+        Command::PART(channel_list, None).into()
+    }
+
+    fn new_quit(message: String) -> Self {
+        const DEFAULT_QUIT_MESSAGE: &str = "Powered by Rust.";
+        Command::QUIT(Some(if message.is_empty() {
+            DEFAULT_QUIT_MESSAGE.to_string()
+        } else {
+            message
+        }))
+        .into()
+    }
+
+    // User Authentication
+
+    fn new_pass(password: String) -> Self {
+        Command::PASS(password).into()
+    }
+
+    fn new_authenticated_join(channel_list: String, pass_list: String) -> Self {
+        Command::JOIN(channel_list, Some(pass_list), None).into()
+    }
+
+    fn new_nickserv(commands: Vec<String>) -> Self {
+        Command::NICKSERV(commands).into()
     }
 }
 
@@ -71,6 +186,10 @@ impl InternalIrcMessageIncoming for irc_proto::Message {
 
     fn is_pong(&self) -> bool {
         matches!(self.command, Command::PONG(..))
+    }
+
+    fn is_quit(&self) -> bool {
+        matches!(self.command, Command::QUIT(..))
     }
 
     fn as_ping(&self) -> Option<String> {

--- a/src/client/data/codec.rs
+++ b/src/client/data/codec.rs
@@ -21,31 +21,46 @@ pub trait MessageCodec:
 
     /// Construct an instance of the codec based on the given character encoding.
     fn try_new(char_encoding: impl AsRef<str>) -> Result<Self, ProtocolError>;
+
+    /// Sanitizes the input string by cutting up to (and including) the first occurence of a line
+    /// terminiating phrase (`\r\n`, `\r`, or `\n`). This is used in sending messages through the
+    /// codec to prevent the injection of additional commands.
+    fn sanitize(mut data: String) -> String {
+        // n.b. ordering matters here to prefer "\r\n" over "\r"
+        if let Some((pos, len)) = ["\r\n", "\r", "\n"]
+            .iter()
+            .flat_map(|needle| data.find(needle).map(|pos| (pos, needle.len())))
+            .min_by_key(|&(pos, _)| pos)
+        {
+            data.truncate(pos + len);
+        }
+        data
+    }
 }
 
 #[cfg(feature = "essentials")]
-/// Helper trait to feature gate the `From<crate::proto::Command>` dependency.
+/// Helper trait to feature gate the [`From<crate::proto::Command>`] dependency (which is currently required anything other than barebones mode).
 pub trait InternalIrcMessageOutgoingBase: From<crate::proto::Command> {}
 
 #[cfg(feature = "essentials")]
 impl<T> InternalIrcMessageOutgoingBase for T where T: From<crate::proto::Command> {}
 
 #[cfg(not(feature = "essentials"))]
-/// Helper trait to feature gate the `From<crate::proto::Command>` dependency.
+/// Helper trait to feature gate the [`From<crate::proto::Command>`] dependency.
 pub trait InternalIrcMessageOutgoingBase {}
 
 #[cfg(not(feature = "essentials"))]
 impl<T> InternalIrcMessageOutgoingBase for T {}
 
 #[cfg(feature = "essentials")]
-/// Helper trait to feature gate the `Borrow<crate::proto::Message>` dependency.
+/// Helper trait to feature gate the [`std::borrow::Borrow<crate::proto::Message>`] dependency.
 pub trait InternalIrcMessageIncomingBase: std::borrow::Borrow<crate::proto::Message> {}
 
 #[cfg(feature = "essentials")]
 impl<T> InternalIrcMessageIncomingBase for T where T: std::borrow::Borrow<crate::proto::Message> {}
 
 #[cfg(not(feature = "essentials"))]
-/// Helper trait to feature gate the `Borrow<crate::proto::Message>` dependency.
+/// Helper trait to feature gate the [`std::borrow::Borrow<crate::proto::Message>`] dependency.
 pub trait InternalIrcMessageIncomingBase {}
 
 #[cfg(not(feature = "essentials"))]
@@ -53,62 +68,107 @@ impl<T> InternalIrcMessageIncomingBase for T {}
 
 /// An message type that supports decoding the commands necessary to maintain communication with a basic IRC server.
 pub trait InternalIrcMessageIncoming: InternalIrcMessageIncomingBase {
+    // Override if you want to be able to join channels:
+
     /// Whether or not this message is a `RPL_ENDOFMOTD` response.
-    fn is_end_of_motd(&self) -> bool;
+    fn is_end_of_motd(&self) -> bool {
+        false
+    }
 
     /// Whether or not this message is a `ERR_NOMOTD` response.
-    fn is_err_nomotd(&self) -> bool;
+    fn is_err_nomotd(&self) -> bool {
+        false
+    }
+
+    // Override if you don't want to time out after a few minutes:
 
     /// Whether or not this message is a `PONG` message.
-    fn is_pong(&self) -> bool;
-
-    /// Whether or not this message is a `QUIT` message.
-    fn is_quit(&self) -> bool;
+    fn is_pong(&self) -> bool {
+        false
+    }
 
     /// If this message is a `PING` message, this returns the payload.
-    fn as_ping(&self) -> Option<String>;
+    fn as_ping<'a>(&'a self) -> Option<&'a str> {
+        None
+    }
+
+    // Override if you want to be able to know when you've been kicked out of a server:
+
+    /// Whether or not this message is a `QUIT` message.
+    fn is_quit(&self) -> bool {
+        false
+    }
 }
 
 /// An message type that supports encoding enough message types to maintain communication with an IRC server.
+/// All functions can be deduced automatically as long as `new_raw` is implemented.
 pub trait InternalIrcMessageOutgoing: InternalIrcMessageOutgoingBase {
+    /// Create a message from scratch.
+    fn new_raw(command: String, arguments: Vec<String>) -> Self;
+
     // Basic functionality
     // Encode message types that are absolutely necessary for the communication even with basic IRC servers.
 
     /// Create a `PING` message.
-    fn new_ping(server: String) -> Self;
+    fn new_ping(server: String) -> Self {
+        Self::new_raw("PING".to_owned(), vec![server])
+    }
 
     /// Create a `PONG` message.
-    fn new_pong(daemon: String) -> Self;
+    fn new_pong(daemon: String) -> Self {
+        Self::new_raw("PONG".to_owned(), vec![daemon])
+    }
 
     /// Create a `CAP END` message (end of capabilities request).
-    fn new_cap_end() -> Self;
+    fn new_cap_end() -> Self {
+        Self::new_raw("CAP".to_owned(), vec!["END".to_owned()])
+    }
 
     /// Create a `NICK` message.
-    fn new_nick(nick: String) -> Self;
+    fn new_nick(nick: String) -> Self {
+        Self::new_raw("NICK".to_owned(), vec![nick])
+    }
 
     /// Create a `USER` message. The user mode will be set to `0`.
-    fn new_user(username: String, realname: String) -> Self;
+    fn new_user(username: String, realname: String) -> Self {
+        Self::new_raw(
+            "USER".to_owned(),
+            vec![username, "0".to_owned(), "*".to_owned(), realname],
+        )
+    }
 
     /// Create a `JOIN` message for channels that do not require authentification.
-    fn new_join(channel_list: String) -> Self;
+    fn new_join(channel_list: String) -> Self {
+        Self::new_raw("JOIN".to_owned(), vec![channel_list])
+    }
 
     /// Create a `PART` message.
-    fn new_part(channel_list: String) -> Self;
+    fn new_part(channel_list: String) -> Self {
+        Self::new_raw("PART".to_owned(), vec![channel_list])
+    }
 
     /// Create a `QUIT` message.
-    fn new_quit(message: String) -> Self;
+    fn new_quit(message: String) -> Self {
+        Self::new_raw("QUIT".to_owned(), vec![message])
+    }
 
     // User Authentification
     // Encode message types necessary to authenticate users.
 
     /// Create a `PASS` message.
-    fn new_pass(password: String) -> Self;
+    fn new_pass(password: String) -> Self {
+        Self::new_raw("PASS".to_owned(), vec![password])
+    }
 
     /// Create a `JOIN` message for channels that require authentification.
-    fn new_authenticated_join(channel_list: String, pass_list: String) -> Self;
+    fn new_authenticated_join(channel_list: String, pass_list: String) -> Self {
+        Self::new_raw("JOIN".to_owned(), vec![channel_list, pass_list])
+    }
 
     /// Create a `NICKSERV` message.
-    fn new_nickserv(commands: Vec<String>) -> Self;
+    fn new_nickserv(commands: Vec<String>) -> Self {
+        Self::new_raw("NICKSERV".to_owned(), commands)
+    }
 }
 
 /// A message type that supports encoding message types necessary to authenticate a password-protected user.
@@ -123,6 +183,22 @@ impl MessageCodec for IrcCodec {
 }
 
 impl InternalIrcMessageOutgoing for irc_proto::Message {
+    fn new_raw(command: String, arguments: Vec<String>) -> Self {
+        Command::Raw(command, arguments).into()
+    }
+
+    fn new_quit(message: String) -> Self {
+        const DEFAULT_QUIT_MESSAGE: &str = "Powered by Rust.";
+        Command::QUIT(Some(if message.is_empty() {
+            DEFAULT_QUIT_MESSAGE.to_string()
+        } else {
+            message
+        }))
+        .into()
+    }
+
+    // Implementations below aren't strictly necessary since they should be equal to the default implementations.
+    // However, they are included here to make sure that no new bugs are introduced.
     fn new_ping(server: String) -> Self {
         Command::PING(server, None).into()
     }
@@ -150,18 +226,6 @@ impl InternalIrcMessageOutgoing for irc_proto::Message {
     fn new_part(channel_list: String) -> Self {
         Command::PART(channel_list, None).into()
     }
-
-    fn new_quit(message: String) -> Self {
-        const DEFAULT_QUIT_MESSAGE: &str = "Powered by Rust.";
-        Command::QUIT(Some(if message.is_empty() {
-            DEFAULT_QUIT_MESSAGE.to_string()
-        } else {
-            message
-        }))
-        .into()
-    }
-
-    // User Authentication
 
     fn new_pass(password: String) -> Self {
         Command::PASS(password).into()
@@ -192,9 +256,9 @@ impl InternalIrcMessageIncoming for irc_proto::Message {
         matches!(self.command, Command::QUIT(..))
     }
 
-    fn as_ping(&self) -> Option<String> {
+    fn as_ping<'a>(&'a self) -> Option<&'a str> {
         if let Command::PING(ref payload, _) = self.command {
-            Some(payload.clone())
+            Some(payload.as_ref())
         } else {
             None
         }

--- a/src/client/data/codec.rs
+++ b/src/client/data/codec.rs
@@ -1,0 +1,83 @@
+//! A trait that describes a codec that can be used to encode or decode IRC messages.
+//! At the moment, this is just a wrapper around [`tokio_util::codec::Decoder`] and [`tokio_util::codec::Encoder`].
+
+use irc_proto::{error::ProtocolError, Command, IrcCodec, Response};
+use std::fmt::{Debug, Display};
+
+pub use tokio_util::codec::{Decoder, Encoder};
+
+/// A codec that can be used to encode or decode IRC messages.
+pub trait MessageCodec:
+    Decoder<Item = <Self as MessageCodec>::MsgItem> + Encoder<<Self as MessageCodec>::MsgItem> + Sized
+{
+    /// The type of the message that this codec expects for messages that we want to send.
+    type MsgItem: Display + Debug + Clone + InternalIrcMessageIncoming + InternalIrcMessageOutgoing;
+
+    /// Construct an instance of the codec based on the given character encoding.
+    fn try_new(char_encoding: impl AsRef<str>) -> Result<Self, ProtocolError>;
+}
+
+/// An message type that supports decoding all commands necessary to maintain communication with an IRC server.
+/// For this crate, such messages have to support the `RESPONSE` and `PING` commands.
+pub trait InternalIrcMessageIncoming {
+    /// Whether or not this message is a `RPL_ENDOFMOTD` response.
+    fn is_end_of_motd(&self) -> bool;
+
+    /// Whether or not this message is a `ERR_NOMOTD` response.
+    fn is_err_nomotd(&self) -> bool;
+
+    /// Whether or not this message is a `PONG` message.
+    fn is_pong(&self) -> bool;
+
+    /// If this message is a `PING` message, this returns the payload.
+    fn as_ping(&self) -> Option<String>;
+}
+
+/// An message type that supports encoding all commands necessary to maintain communication with an IRC server.
+/// For this crate, such messages have to support the `PING` and `PONG` commands.
+pub trait InternalIrcMessageOutgoing {
+    /// Create a `PING` message.
+    fn new_ping(server: String, server_fwd: Option<String>) -> Self;
+
+    /// Create a `PONG` message.
+    fn new_pong(daemon: String, daemon_fwd: Option<String>) -> Self;
+}
+
+impl MessageCodec for IrcCodec {
+    type MsgItem = irc_proto::Message;
+
+    fn try_new(char_encoding: impl AsRef<str>) -> Result<Self, ProtocolError> {
+        Self::new(char_encoding.as_ref())
+    }
+}
+
+impl InternalIrcMessageOutgoing for irc_proto::Message {
+    fn new_ping(server: String, server_fwd: Option<String>) -> Self {
+        Command::PING(server, server_fwd).into()
+    }
+
+    fn new_pong(daemon: String, daemon_fwd: Option<String>) -> Self {
+        Command::PONG(daemon, daemon_fwd).into()
+    }
+}
+
+impl InternalIrcMessageIncoming for irc_proto::Message {
+    fn is_end_of_motd(&self) -> bool {
+        matches!(self.command, Command::Response(Response::RPL_ENDOFMOTD, _))
+    }
+    fn is_err_nomotd(&self) -> bool {
+        matches!(self.command, Command::Response(Response::ERR_NOMOTD, _))
+    }
+
+    fn is_pong(&self) -> bool {
+        matches!(self.command, Command::PONG(..))
+    }
+
+    fn as_ping(&self) -> Option<String> {
+        if let Command::PING(ref payload, _) = self.command {
+            Some(payload.clone())
+        } else {
+            None
+        }
+    }
+}

--- a/src/client/data/mod.rs
+++ b/src/client/data/mod.rs
@@ -5,6 +5,7 @@ pub use crate::client::data::config::Config;
 pub use crate::client::data::proxy::ProxyType;
 pub use crate::client::data::user::{AccessLevel, User};
 
+pub mod codec;
 pub mod config;
 #[cfg(feature = "proxy")]
 pub mod proxy;

--- a/src/client/mod.rs
+++ b/src/client/mod.rs
@@ -93,6 +93,8 @@ use crate::proto::{
 
 // we use our own feature-dependent extension of the traits
 use self::data::codec::{InternalIrcMessageIncoming, InternalIrcMessageOutgoing};
+
+#[cfg(feature = "essentials")]
 use irc_interface::InternalIrcMessageOutgoing as _;
 
 pub mod conn;
@@ -1294,8 +1296,14 @@ pub mod codec_tests {
 
     use crate::client::{Client, Config, MessageCodec};
 
-    use super::data::codec::{InternalIrcMessageIncoming, InternalIrcMessageOutgoing};
-    use irc_interface::InternalIrcMessageOutgoing as _;
+    #[cfg(not(feature = "essentials"))]
+    use irc_interface::{InternalIrcMessageIncoming, InternalIrcMessageOutgoing};
+
+    #[cfg(feature = "essentials")]
+    use {
+        super::data::codec::{InternalIrcMessageIncoming, InternalIrcMessageOutgoing},
+        irc_interface::InternalIrcMessageOutgoing as _,
+    };
 
     pub fn test_config() -> Config {
         Config {

--- a/src/client/mod.rs
+++ b/src/client/mod.rs
@@ -63,7 +63,7 @@ use irc_interface::{Decoder, Encoder, MessageCodec};
 use parking_lot::RwLock;
 use std::{
     collections::HashMap,
-    fmt,
+    fmt::{self, Debug},
     path::Path,
     pin::Pin,
     sync::Arc,

--- a/src/client/mod.rs
+++ b/src/client/mod.rs
@@ -1082,7 +1082,7 @@ where
 {
     /// Creates a new `Client` from the configuration at the specified path, connecting
     /// immediately. This function is short-hand for loading the configuration and then calling
-    /// `Client::from_config` and consequently inherits its behaviors.
+    /// `Client::from_config_with_codec` and consequently inherits its behaviors.
     ///
     /// # Example
     /// ```no_run

--- a/src/client/mod.rs
+++ b/src/client/mod.rs
@@ -36,6 +36,7 @@
 //! let mut stream = client.stream()?;
 //! client.identify()?;
 //!
+//! # #[cfg(feature = "essentials")]
 //! while let Some(message) = stream.next().await.transpose()? {
 //!     if let Command::PRIVMSG(channel, message) = message.command {
 //!         if message.contains(client.current_nickname()) {
@@ -68,24 +69,32 @@ use std::{
     task::{Context, Poll},
 };
 use tokio::sync::mpsc::{self, UnboundedReceiver, UnboundedSender};
+use tokio_util::codec::{Decoder, Encoder};
 
 use crate::{
     client::{
         conn::Connection,
-        data::{Config, User},
+        data::{
+            codec::{InternalIrcMessageOutgoing, MessageCodec},
+            Config, User,
+        },
     },
     error,
-    proto::{
-        mode::ModeType,
-        CapSubCommand::{END, LS, REQ},
-        Capability, ChannelMode, Command,
-        Command::{
-            ChannelMODE, AUTHENTICATE, CAP, INVITE, JOIN, KICK, KILL, NICK, NICKSERV, NOTICE, OPER,
-            PART, PASS, PONG, PRIVMSG, QUIT, SAMODE, SANICK, TOPIC, USER,
-        },
-        Message, Mode, NegotiationVersion, Response,
-    },
 };
+
+#[cfg(feature = "essentials")]
+use crate::proto::{
+    mode::ModeType,
+    CapSubCommand::{LS, REQ},
+    Capability, ChannelMode, Command,
+    Command::{
+        ChannelMODE, AUTHENTICATE, CAP, INVITE, JOIN, KICK, KILL, NICK, NOTICE, OPER, PART,
+        PRIVMSG, QUIT, SAMODE, SANICK, TOPIC,
+    },
+    Message, Mode, NegotiationVersion, Response,
+};
+
+use self::data::codec::InternalIrcMessageIncoming;
 
 pub mod conn;
 pub mod data;
@@ -93,12 +102,13 @@ mod mock;
 pub mod prelude;
 pub mod transport;
 
-/// The IRC Codec that this crate uses by default.
+/// The IRC Codec that is used when no other codec is specified.
 type DefaultCodec = irc_proto::IrcCodec;
 
 macro_rules! pub_state_base {
-    () => {
+    ($msg_type:ty) => {
         /// Changes the modes for the specified target.
+        #[cfg(feature = "essentials")]
         pub fn send_mode<S, T>(&self, target: S, modes: &[Mode<T>]) -> error::Result<()>
         where
             S: fmt::Display,
@@ -112,7 +122,7 @@ macro_rules! pub_state_base {
         where
             S: fmt::Display,
         {
-            self.send(JOIN(chanlist.to_string(), None, None))
+            self.send(<$msg_type>::new_join(chanlist.to_string()))
         }
 
         /// Joins the specified channel or chanlist using the specified key or keylist.
@@ -125,10 +135,14 @@ macro_rules! pub_state_base {
             S1: fmt::Display,
             S2: fmt::Display,
         {
-            self.send(JOIN(chanlist.to_string(), Some(keylist.to_string()), None))
+            self.send(<$msg_type>::new_authenticated_join(
+                chanlist.to_string(),
+                keylist.to_string(),
+            ))
         }
 
         /// Sends a notice to the specified target.
+        #[cfg(all(feature = "ctcp", feature = "essentials"))]
         pub fn send_notice<S1, S2>(&self, target: S1, message: S2) -> error::Result<()>
         where
             S1: fmt::Display,
@@ -144,8 +158,9 @@ macro_rules! pub_state_base {
 }
 
 macro_rules! pub_sender_base {
-    () => {
+    ($msg_type:ty) => {
         /// Sends a request for a list of server capabilities for a specific IRCv3 version.
+        #[cfg(feature = "essentials")]
         pub fn send_cap_ls(&self, version: NegotiationVersion) -> error::Result<()> {
             self.send(Command::CAP(
                 None,
@@ -159,6 +174,7 @@ macro_rules! pub_sender_base {
         }
 
         /// Sends an IRCv3 capabilities request for the specified extensions.
+        #[cfg(feature = "essentials")]
         pub fn send_cap_req(&self, extensions: &[Capability]) -> error::Result<()> {
             let append = |mut s: String, c| {
                 s.push_str(c);
@@ -175,21 +191,25 @@ macro_rules! pub_sender_base {
         }
 
         /// Sends a SASL AUTHENTICATE message with the specified data.
+        #[cfg(feature = "essentials")]
         pub fn send_sasl<S: fmt::Display>(&self, data: S) -> error::Result<()> {
             self.send(AUTHENTICATE(data.to_string()))
         }
 
         /// Sends a SASL AUTHENTICATE request to use the PLAIN mechanism.
+        #[cfg(feature = "essentials")]
         pub fn send_sasl_plain(&self) -> error::Result<()> {
             self.send_sasl("PLAIN")
         }
 
         /// Sends a SASL AUTHENTICATE request to use the EXTERNAL mechanism.
+        #[cfg(feature = "essentials")]
         pub fn send_sasl_external(&self) -> error::Result<()> {
             self.send_sasl("EXTERNAL")
         }
 
         /// Sends a SASL AUTHENTICATE request to abort authentication.
+        #[cfg(feature = "essentials")]
         pub fn send_sasl_abort(&self) -> error::Result<()> {
             self.send_sasl("*")
         }
@@ -199,7 +219,7 @@ macro_rules! pub_sender_base {
         where
             S: fmt::Display,
         {
-            self.send(PONG(msg.to_string(), None))
+            self.send(<$msg_type>::new_pong(msg.to_string()))
         }
 
         /// Parts the specified channel or chanlist.
@@ -207,10 +227,11 @@ macro_rules! pub_sender_base {
         where
             S: fmt::Display,
         {
-            self.send(PART(chanlist.to_string(), None))
+            self.send(<$msg_type>::new_part(chanlist.to_string()))
         }
 
         /// Attempts to oper up using the specified username and password.
+        #[cfg(feature = "essentials")]
         pub fn send_oper<S1, S2>(&self, username: S1, password: S2) -> error::Result<()>
         where
             S1: fmt::Display,
@@ -223,6 +244,7 @@ macro_rules! pub_sender_base {
         /// will automatically be split and sent as multiple separate `PRIVMSG`s to the specified
         /// target. If you absolutely must avoid this behavior, you can do
         /// `client.send(PRIVMSG(target, message))` directly.
+        #[cfg(feature = "essentials")]
         pub fn send_privmsg<S1, S2>(&self, target: S1, message: S2) -> error::Result<()>
         where
             S1: fmt::Display,
@@ -237,6 +259,7 @@ macro_rules! pub_sender_base {
 
         /// Sets the topic of a channel or requests the current one.
         /// If `topic` is an empty string, it won't be included in the message.
+        #[cfg(feature = "essentials")]
         pub fn send_topic<S1, S2>(&self, channel: S1, topic: S2) -> error::Result<()>
         where
             S1: fmt::Display,
@@ -250,6 +273,7 @@ macro_rules! pub_sender_base {
         }
 
         /// Kills the target with the provided message.
+        #[cfg(feature = "essentials")]
         pub fn send_kill<S1, S2>(&self, target: S1, message: S2) -> error::Result<()>
         where
             S1: fmt::Display,
@@ -260,6 +284,7 @@ macro_rules! pub_sender_base {
 
         /// Kicks the listed nicknames from the listed channels with a comment.
         /// If `message` is an empty string, it won't be included in the message.
+        #[cfg(feature = "essentials")]
         pub fn send_kick<S1, S2, S3>(
             &self,
             chanlist: S1,
@@ -285,6 +310,7 @@ macro_rules! pub_sender_base {
 
         /// Changes the mode of the target by force.
         /// If `modeparams` is an empty string, it won't be included in the message.
+        #[cfg(feature = "essentials")]
         pub fn send_samode<S1, S2, S3>(
             &self,
             target: S1,
@@ -309,6 +335,7 @@ macro_rules! pub_sender_base {
         }
 
         /// Forces a user to change from the old nickname to the new nickname.
+        #[cfg(feature = "essentials")]
         pub fn send_sanick<S1, S2>(&self, old_nick: S1, new_nick: S2) -> error::Result<()>
         where
             S1: fmt::Display,
@@ -318,6 +345,7 @@ macro_rules! pub_sender_base {
         }
 
         /// Invites a user to the specified channel.
+        #[cfg(feature = "essentials")]
         pub fn send_invite<S1, S2>(&self, nick: S1, chan: S2) -> error::Result<()>
         where
             S1: fmt::Display,
@@ -333,11 +361,7 @@ macro_rules! pub_sender_base {
             S: fmt::Display,
         {
             let msg = msg.to_string();
-            self.send(QUIT(Some(if msg.is_empty() {
-                "Powered by Rust.".to_string()
-            } else {
-                msg
-            })))
+            self.send(<$msg_type>::new_quit(msg.to_string()))
         }
 
         /// Sends a CTCP-escaped message to the specified target.
@@ -439,16 +463,24 @@ macro_rules! pub_sender_base {
 /// [`futures`](https://docs.rs/futures/) crate, or the tutorials for
 /// [`tokio`](https://tokio.rs/docs/getting-started/futures/).
 #[derive(Debug)]
-pub struct ClientStream {
-    state: Arc<ClientState>,
-    stream: SplitStream<Connection<DefaultCodec>>,
+pub struct ClientStream<Codec = DefaultCodec>
+where
+    Codec: MessageCodec,
+    error::Error: From<<Codec as Decoder>::Error> + From<<Codec as Encoder<Codec::MsgItem>>::Error>,
+{
+    state: Arc<ClientState<Codec>>,
+    stream: SplitStream<Connection<Codec>>,
     // In case the client stream also handles outgoing messages.
-    outgoing: Option<Outgoing>,
+    outgoing: Option<Outgoing<Codec>>,
 }
 
-impl ClientStream {
+impl<Codec> ClientStream<Codec>
+where
+    Codec: MessageCodec,
+    error::Error: From<<Codec as Decoder>::Error> + From<<Codec as Encoder<Codec::MsgItem>>::Error>,
+{
     /// collect stream and collect all messages available.
-    pub async fn collect(mut self) -> error::Result<Vec<Message>> {
+    pub async fn collect(mut self) -> error::Result<Vec<Codec::MsgItem>> {
         let mut output = Vec::new();
 
         while let Some(message) = self.next().await {
@@ -462,14 +494,22 @@ impl ClientStream {
     }
 }
 
-impl FusedStream for ClientStream {
+impl<Codec> FusedStream for ClientStream<Codec>
+where
+    Codec: MessageCodec,
+    error::Error: From<<Codec as Decoder>::Error> + From<<Codec as Encoder<Codec::MsgItem>>::Error>,
+{
     fn is_terminated(&self) -> bool {
         false
     }
 }
 
-impl Stream for ClientStream {
-    type Item = Result<Message, error::Error>;
+impl<Codec> Stream for ClientStream<Codec>
+where
+    Codec: MessageCodec,
+    error::Error: From<<Codec as Decoder>::Error> + From<<Codec as Encoder<Codec::MsgItem>>::Error>,
+{
+    type Item = Result<Codec::MsgItem, error::Error>;
 
     fn poll_next(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Option<Self::Item>> {
         if let Some(outgoing) = self.as_mut().outgoing.as_mut() {
@@ -499,8 +539,12 @@ impl Stream for ClientStream {
 
 /// Thread-safe internal state for an IRC server connection.
 #[derive(Debug)]
-struct ClientState {
-    sender: Sender,
+struct ClientState<Codec = DefaultCodec>
+where
+    Codec: MessageCodec,
+    error::Error: From<<Codec as Decoder>::Error>,
+{
+    sender: Sender<Codec::MsgItem>,
     /// The configuration used with this connection.
     config: Config,
     /// A thread-safe map of channels to the list of users in them.
@@ -511,8 +555,13 @@ struct ClientState {
     default_ghost_sequence: Vec<String>,
 }
 
-impl ClientState {
-    fn new(sender: Sender, config: Config) -> ClientState {
+impl<Codec> ClientState<Codec>
+where
+    Codec: MessageCodec,
+    error::Error: From<<Codec as Decoder>::Error>,
+    Codec::MsgItem: InternalIrcMessageIncoming + InternalIrcMessageOutgoing,
+{
+    fn new(sender: Sender<Codec::MsgItem>, config: Config) -> ClientState<Codec> {
         ClientState {
             sender,
             config,
@@ -526,7 +575,7 @@ impl ClientState {
         &self.config
     }
 
-    fn send<M: Into<Message>>(&self, msg: M) -> error::Result<()> {
+    fn send<M: Into<Codec::MsgItem>>(&self, msg: M) -> error::Result<()> {
         let msg = msg.into();
         self.handle_sent_message(&msg)?;
         Ok(self.sender.send(msg)?)
@@ -547,22 +596,41 @@ impl ClientState {
     }
 
     /// Handles sent messages internally for basic client functionality.
-    fn handle_sent_message(&self, msg: &Message) -> error::Result<()> {
+    fn handle_sent_message(&self, msg: &Codec::MsgItem) -> error::Result<()> {
         log::trace!("[SENT] {}", msg.to_string());
 
-        match msg.command {
-            PART(ref chan, _) => {
-                let _ = self.chanlists.write().remove(chan);
+        #[cfg(feature = "essentials")]
+        {
+            let msg = <Codec::MsgItem as std::borrow::Borrow<Message>>::borrow(msg);
+            match msg.command {
+                PART(ref chan, _) => {
+                    let _ = self.chanlists.write().remove(chan);
+                }
+                _ => (),
             }
-            _ => (),
         }
 
         Ok(())
     }
 
     /// Handles received messages internally for basic client functionality.
-    fn handle_message(&self, msg: &Message) -> error::Result<()> {
+    #[cfg(not(feature = "essentials"))]
+    fn handle_message(&self, msg: &Codec::MsgItem) -> error::Result<()> {
         log::trace!("[RECV] {}", msg.to_string());
+        if msg.is_quit() {
+            self.handle_quit("")
+        } else if msg.is_end_of_motd() || msg.is_err_nomotd() {
+            self.handle_motd()?
+        }
+        Ok(())
+    }
+
+    /// Handles received messages internally for basic client functionality.
+    #[cfg(feature = "essentials")]
+    fn handle_message(&self, msg: &Codec::MsgItem) -> error::Result<()> {
+        log::trace!("[RECV] {}", msg.to_string());
+
+        let msg = <Codec::MsgItem as std::borrow::Borrow<Message>>::borrow(msg);
         match msg.command {
             JOIN(ref chan, _, _) => self.handle_join(msg.source_nickname().unwrap_or(""), chan),
             PART(ref chan, _) => self.handle_part(msg.source_nickname().unwrap_or(""), chan),
@@ -591,25 +659,7 @@ impl ClientState {
             }
             Command::Response(Response::RPL_NAMREPLY, ref args) => self.handle_namreply(args),
             Command::Response(Response::RPL_ENDOFMOTD, _)
-            | Command::Response(Response::ERR_NOMOTD, _) => {
-                self.send_nick_password()?;
-                self.send_umodes()?;
-
-                let config_chans = self.config().channels();
-                for chan in config_chans {
-                    match self.config().channel_key(chan) {
-                        Some(key) => self.send_join_with_keys::<&str, &str>(chan, key)?,
-                        None => self.send_join(chan)?,
-                    }
-                }
-                let joined_chans = self.chanlists.read();
-                for chan in joined_chans
-                    .keys()
-                    .filter(|x| config_chans.iter().find(|c| c == x).is_none())
-                {
-                    self.send_join(chan)?
-                }
-            }
+            | Command::Response(Response::ERR_NOMOTD, _) => self.handle_motd()?,
             Command::Response(Response::ERR_NICKNAMEINUSE, _)
             | Command::Response(Response::ERR_ERRONEOUSNICKNAME, _) => {
                 let alt_nicks = self.config().alternate_nicknames();
@@ -627,6 +677,30 @@ impl ClientState {
         Ok(())
     }
 
+    /// Send join messages after the MOTD has been received.
+    fn handle_motd(&self) -> error::Result<()> {
+        self.send_nick_password()?;
+        #[cfg(feature = "essentials")]
+        self.send_umodes()?;
+
+        let config_chans = self.config().channels();
+        for chan in config_chans {
+            match self.config().channel_key(chan) {
+                Some(key) => self.send_join_with_keys::<&str, &str>(chan, key)?,
+                None => self.send_join(chan)?,
+            }
+        }
+        let joined_chans = self.chanlists.read();
+        for chan in joined_chans
+            .keys()
+            .filter(|x| config_chans.iter().find(|c| c == x).is_none())
+        {
+            self.send_join(chan)?
+        }
+
+        Ok(())
+    }
+
     fn send_nick_password(&self) -> error::Result<()> {
         if self.config().nick_password().is_empty() {
             Ok(())
@@ -640,23 +714,26 @@ impl ClientState {
                 };
 
                 for s in seq {
-                    self.send(NICKSERV(vec![
+                    self.send(Codec::MsgItem::new_nickserv(vec![
                         s.to_string(),
                         self.config().nickname()?.to_string(),
                         self.config().nick_password().to_string(),
                     ]))?;
                 }
                 *index = 0;
-                self.send(NICK(self.config().nickname()?.to_owned()))?
+                self.send(Codec::MsgItem::new_nick(
+                    self.config().nickname()?.to_owned(),
+                ))?
             }
 
-            self.send(NICKSERV(vec![
+            self.send(Codec::MsgItem::new_nickserv(vec![
                 "IDENTIFY".to_string(),
                 self.config().nick_password().to_string(),
             ]))
         }
     }
 
+    #[cfg(feature = "essentials")]
     fn send_umodes(&self) -> error::Result<()> {
         if self.config().umodes().is_empty() {
             Ok(())
@@ -682,10 +759,10 @@ impl ClientState {
         }
     }
 
-    #[cfg(feature = "nochanlists")]
+    #[cfg(any(feature = "nochanlists"))]
     fn handle_join(&self, _: &str, _: &str) {}
 
-    #[cfg(not(feature = "nochanlists"))]
+    #[cfg(all(not(feature = "nochanlists"), feature = "essentials"))]
     fn handle_join(&self, src: &str, chan: &str) {
         if let Some(vec) = self.chanlists.write().get_mut(&chan.to_owned()) {
             if !src.is_empty() {
@@ -694,10 +771,10 @@ impl ClientState {
         }
     }
 
-    #[cfg(feature = "nochanlists")]
+    #[cfg(any(feature = "nochanlists"))]
     fn handle_part(&self, _: &str, _: &str) {}
 
-    #[cfg(not(feature = "nochanlists"))]
+    #[cfg(all(not(feature = "nochanlists"), feature = "essentials"))]
     fn handle_part(&self, src: &str, chan: &str) {
         if let Some(vec) = self.chanlists.write().get_mut(&chan.to_owned()) {
             if !src.is_empty() {
@@ -708,10 +785,10 @@ impl ClientState {
         }
     }
 
-    #[cfg(feature = "nochanlists")]
+    #[cfg(any(feature = "nochanlists", not(feature = "essentials")))]
     fn handle_quit(&self, _: &str) {}
 
-    #[cfg(not(feature = "nochanlists"))]
+    #[cfg(all(not(feature = "nochanlists"), feature = "essentials"))]
     fn handle_quit(&self, src: &str) {
         if src.is_empty() {
             return;
@@ -724,10 +801,10 @@ impl ClientState {
         }
     }
 
-    #[cfg(feature = "nochanlists")]
+    #[cfg(any(feature = "nochanlists"))]
     fn handle_nick_change(&self, _: &str, _: &str) {}
 
-    #[cfg(not(feature = "nochanlists"))]
+    #[cfg(all(not(feature = "nochanlists"), feature = "essentials"))]
     fn handle_nick_change(&self, old_nick: &str, new_nick: &str) {
         if old_nick.is_empty() || new_nick.is_empty() {
             return;
@@ -741,10 +818,10 @@ impl ClientState {
         }
     }
 
-    #[cfg(feature = "nochanlists")]
+    #[cfg(any(feature = "nochanlists"))]
     fn handle_mode(&self, _: &str, _: &[Mode<ChannelMode>]) {}
 
-    #[cfg(not(feature = "nochanlists"))]
+    #[cfg(all(not(feature = "nochanlists"), feature = "essentials"))]
     fn handle_mode(&self, chan: &str, modes: &[Mode<ChannelMode>]) {
         for mode in modes {
             match *mode {
@@ -760,10 +837,10 @@ impl ClientState {
         }
     }
 
-    #[cfg(feature = "nochanlists")]
+    #[cfg(any(feature = "nochanlists"))]
     fn handle_namreply(&self, _: &[String]) {}
 
-    #[cfg(not(feature = "nochanlists"))]
+    #[cfg(all(not(feature = "nochanlists"), feature = "essentials"))]
     fn handle_namreply(&self, args: &[String]) {
         if args.len() == 4 {
             let chan = &args[2];
@@ -777,7 +854,7 @@ impl ClientState {
         }
     }
 
-    #[cfg(feature = "ctcp")]
+    #[cfg(all(feature = "ctcp", feature = "essentials"))]
     fn handle_ctcp(&self, resp: &str, tokens: &[&str]) -> error::Result<()> {
         if tokens.is_empty() {
             return Ok(());
@@ -806,50 +883,64 @@ impl ClientState {
         }
     }
 
-    #[cfg(feature = "ctcp")]
+    #[cfg(all(feature = "ctcp", feature = "essentials"))]
     fn send_ctcp_internal(&self, target: &str, msg: &str) -> error::Result<()> {
         self.send_notice(target, &format!("\u{001}{}\u{001}", msg))
     }
 
-    #[cfg(not(feature = "ctcp"))]
+    #[cfg(all(not(feature = "ctcp"), feature = "essentials"))]
     fn handle_ctcp(&self, _: &str, _: &[&str]) -> error::Result<()> {
         Ok(())
     }
 
-    pub_state_base!();
+    pub_state_base!(<Codec as MessageCodec>::MsgItem);
 }
 
 /// Thread-safe sender that can be used with the client.
 #[derive(Debug, Clone)]
-pub struct Sender {
-    tx_outgoing: UnboundedSender<Message>,
+pub struct Sender<MsgItem = <DefaultCodec as MessageCodec>::MsgItem>
+where
+    MsgItem: InternalIrcMessageOutgoing + InternalIrcMessageIncoming,
+{
+    tx_outgoing: UnboundedSender<MsgItem>,
 }
 
-impl Sender {
+impl<MsgItem> Sender<MsgItem>
+where
+    MsgItem: InternalIrcMessageOutgoing + InternalIrcMessageIncoming,
+{
     /// Send a single message to the unbounded queue.
-    pub fn send<M: Into<Message>>(&self, msg: M) -> error::Result<()> {
+    pub fn send<M: Into<MsgItem>>(&self, msg: M) -> error::Result<()> {
         Ok(self.tx_outgoing.send(msg.into())?)
     }
 
-    pub_state_base!();
-    pub_sender_base!();
+    pub_state_base!(MsgItem);
+    pub_sender_base!(MsgItem);
 }
 
 /// Future to handle outgoing messages.
 ///
 /// Note: this is essentially the same as a version of [SendAll](https://github.com/rust-lang-nursery/futures-rs/blob/master/futures-util/src/sink/send_all.rs) that owns it's sink and stream.
 #[derive(Debug)]
-pub struct Outgoing {
-    sink: SplitSink<Connection<DefaultCodec>, Message>,
-    stream: UnboundedReceiver<Message>,
-    buffered: Option<Message>,
+pub struct Outgoing<Codec = DefaultCodec>
+where
+    Codec: MessageCodec,
+    error::Error: From<<Codec as Encoder<Codec::MsgItem>>::Error>,
+{
+    sink: SplitSink<Connection<Codec>, Codec::MsgItem>,
+    stream: UnboundedReceiver<Codec::MsgItem>,
+    buffered: Option<Codec::MsgItem>,
 }
 
-impl Outgoing {
+impl<Codec> Outgoing<Codec>
+where
+    Codec: MessageCodec,
+    error::Error: From<<Codec as Encoder<Codec::MsgItem>>::Error>,
+{
     fn try_start_send(
         &mut self,
         cx: &mut Context<'_>,
-        message: Message,
+        message: Codec::MsgItem,
     ) -> Poll<Result<(), error::Error>> {
         debug_assert!(self.buffered.is_none());
 
@@ -863,7 +954,11 @@ impl Outgoing {
     }
 }
 
-impl FusedFuture for Outgoing {
+impl<Codec> FusedFuture for Outgoing<Codec>
+where
+    Codec: MessageCodec,
+    error::Error: From<<Codec as Encoder<Codec::MsgItem>>::Error>,
+{
     fn is_terminated(&self) -> bool {
         // NB: outgoing stream never terminates.
         // TODO: should it terminate if rx_outgoing is terminated?
@@ -871,7 +966,11 @@ impl FusedFuture for Outgoing {
     }
 }
 
-impl Future for Outgoing {
+impl<Codec> Future for Outgoing<Codec>
+where
+    Codec: MessageCodec,
+    error::Error: From<<Codec as Encoder<Codec::MsgItem>>::Error>,
+{
     type Output = error::Result<()>;
 
     fn poll(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Self::Output> {
@@ -901,21 +1000,33 @@ impl Future for Outgoing {
 ///
 /// For a full example usage, see [`irc::client`](./index.html).
 #[derive(Debug)]
-pub struct Client {
+pub struct Client<Codec = DefaultCodec>
+where
+    Codec: MessageCodec,
+    error::Error: From<<Codec as Decoder>::Error> + From<<Codec as Encoder<Codec::MsgItem>>::Error>,
+    Codec::MsgItem: InternalIrcMessageOutgoing + InternalIrcMessageIncoming,
+{
     /// The internal, thread-safe server state.
-    state: Arc<ClientState>,
-    incoming: Option<SplitStream<Connection<DefaultCodec>>>,
-    outgoing: Option<Outgoing>,
-    sender: Sender,
+    state: Arc<ClientState<Codec>>,
+    incoming: Option<SplitStream<Connection<Codec>>>,
+    outgoing: Option<Outgoing<Codec>>,
+    sender: Sender<Codec::MsgItem>,
     #[cfg(test)]
     /// A view of the logs for a mock connection.
-    view: Option<
-        self::transport::LogView<<DefaultCodec as self::data::codec::MessageCodec>::MsgItem>,
-    >,
+    view: Option<self::transport::LogView<Codec::MsgItem>>,
 }
 
-impl Client {
-    /// Creates a new `Client` from the configuration at the specified path, connecting
+/*
+#HACK   The rust compiler is not able to infer Codec=DefaultCodec in code such as:
+#HACK   `let client = Client::new("config.toml").await?;`
+#HACK   and will instead demand that the user specify the type of Codec.
+#HACK   To make the code above work, we define the constructors `new` and `from_config`
+#HACK   only for the case of Codec=DefaultCodec.
+#HACK   If the user wants to specify a custom codec, they have to use a different constructor,
+#HACK   but at least we stay semver compatible.
+*/
+impl Client<DefaultCodec> {
+    /// Creates a new `Client` with default codec from the configuration at the specified path, connecting
     /// immediately. This function is short-hand for loading the configuration and then calling
     /// `Client::from_config` and consequently inherits its behaviors.
     ///
@@ -928,15 +1039,16 @@ impl Client {
     /// # Ok(())
     /// # }
     /// ```
-    pub async fn new<P: AsRef<Path>>(config: P) -> error::Result<Client> {
-        Client::from_config(Config::load(config)?).await
+    pub async fn new<P: AsRef<Path>>(config: P) -> error::Result<Self> {
+        Self::from_config(Config::load(config)?).await
     }
 
-    /// Creates a `Future` of an `Client` from the specified configuration and on the event loop
+    /// Creates a `Future` of an `Client` with default codec from the specified configuration and on the event loop
     /// corresponding to the given handle. This can be used to set up a number of `Clients` on a
     /// single, shared event loop. It can also be used to take more control over execution and error
     /// handling. Connection will not occur until the event loop is run.
-    pub async fn from_config(config: Config) -> error::Result<Client> {
+    pub async fn from_config(config: Config) -> error::Result<Self> {
+        type Codec = DefaultCodec;
         let (tx_outgoing, rx_outgoing) = mpsc::unbounded_channel();
         let conn = Connection::new(&config, tx_outgoing.clone()).await?;
 
@@ -945,13 +1057,67 @@ impl Client {
 
         let (sink, incoming) = conn.split();
 
-        let sender = Sender { tx_outgoing };
+        let sender = Sender::<<Codec as MessageCodec>::MsgItem> { tx_outgoing };
 
-        Ok(Client {
+        Ok(Self {
             sender: sender.clone(),
-            state: Arc::new(ClientState::new(sender, config)),
+            state: Arc::new(ClientState::<Codec>::new(sender, config)),
             incoming: Some(incoming),
-            outgoing: Some(Outgoing {
+            outgoing: Some(Outgoing::<Codec> {
+                sink,
+                stream: rx_outgoing,
+                buffered: None,
+            }),
+            #[cfg(test)]
+            view,
+        })
+    }
+}
+
+impl<Codec> Client<Codec>
+where
+    Codec: MessageCodec,
+    error::Error: From<<Codec as Decoder>::Error> + From<<Codec as Encoder<Codec::MsgItem>>::Error>,
+    Codec::MsgItem: InternalIrcMessageOutgoing + InternalIrcMessageIncoming,
+{
+    /// Creates a new `Client` from the configuration at the specified path, connecting
+    /// immediately. This function is short-hand for loading the configuration and then calling
+    /// `Client::from_config` and consequently inherits its behaviors.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use irc::client::prelude::*;
+    /// # use irc_proto::IrcCodec;
+    /// # #[tokio::main]
+    /// # async fn main() -> irc::error::Result<()> {
+    /// let client = Client::<IrcCodec>::new_with_codec("config.toml").await?;
+    /// # Ok(())
+    /// # }
+    /// ```
+    pub async fn new_with_codec<P: AsRef<Path>>(config: P) -> error::Result<Self> {
+        Self::from_config_with_codec(Config::load(config)?).await
+    }
+
+    /// Creates a `Future` of an `Client` from the specified configuration and on the event loop
+    /// corresponding to the given handle. This can be used to set up a number of `Clients` on a
+    /// single, shared event loop. It can also be used to take more control over execution and error
+    /// handling. Connection will not occur until the event loop is run.
+    pub async fn from_config_with_codec(config: Config) -> error::Result<Self> {
+        let (tx_outgoing, rx_outgoing) = mpsc::unbounded_channel();
+        let conn = Connection::new(&config, tx_outgoing.clone()).await?;
+
+        #[cfg(test)]
+        let view = conn.log_view();
+
+        let (sink, incoming) = conn.split();
+
+        let sender = Sender::<Codec::MsgItem> { tx_outgoing };
+
+        Ok(Self {
+            sender: sender.clone(),
+            state: Arc::new(ClientState::<Codec>::new(sender, config)),
+            incoming: Some(incoming),
+            outgoing: Some(Outgoing::<Codec> {
                 sink,
                 stream: rx_outgoing,
                 buffered: None,
@@ -963,9 +1129,7 @@ impl Client {
 
     /// Gets the log view from the internal transport. Only used for unit testing.
     #[cfg(test)]
-    fn log_view(
-        &self,
-    ) -> &self::transport::LogView<<DefaultCodec as self::data::codec::MessageCodec>::MsgItem> {
+    fn log_view(&self) -> &self::transport::LogView<Codec::MsgItem> {
         self.view
             .as_ref()
             .expect("there should be a log during testing")
@@ -975,12 +1139,12 @@ impl Client {
     ///
     /// Must be called before `stream` if you intend to drive this future
     /// yourself.
-    pub fn outgoing(&mut self) -> Option<Outgoing> {
+    pub fn outgoing(&mut self) -> Option<Outgoing<Codec>> {
         self.outgoing.take()
     }
 
     /// Get access to a thread-safe sender that can be used with the client.
-    pub fn sender(&self) -> Sender {
+    pub fn sender(&self) -> Sender<Codec::MsgItem> {
         self.sender.clone()
     }
 
@@ -997,13 +1161,13 @@ impl Client {
     ///
     /// **Note**: The stream can only be returned once. Subsequent attempts will cause a panic.
     // FIXME: when impl traits stabilize, we should change this return type.
-    pub fn stream(&mut self) -> error::Result<ClientStream> {
+    pub fn stream(&mut self) -> error::Result<ClientStream<Codec>> {
         let stream = self
             .incoming
             .take()
             .ok_or_else(|| error::Error::StreamAlreadyConfigured)?;
 
-        Ok(ClientStream {
+        Ok(ClientStream::<Codec> {
             state: Arc::clone(&self.state),
             stream,
             outgoing: self.outgoing.take(),
@@ -1012,7 +1176,7 @@ impl Client {
 
     /// Gets a list of currently joined channels. This will be `None` if tracking is disabled
     /// altogether via the `nochanlists` feature.
-    #[cfg(not(feature = "nochanlists"))]
+    #[cfg(all(not(feature = "nochanlists"), feature = "essentials"))]
     pub fn list_channels(&self) -> Option<Vec<String>> {
         Some(
             self.state
@@ -1024,7 +1188,8 @@ impl Client {
         )
     }
 
-    #[cfg(feature = "nochanlists")]
+    #[cfg(any(feature = "nochanlists", not(feature = "essentials")))]
+    #[allow(missing_docs)]
     pub fn list_channels(&self) -> Option<Vec<String>> {
         None
     }
@@ -1048,12 +1213,13 @@ impl Client {
     /// # Ok(())
     /// # }
     /// ```
-    #[cfg(not(feature = "nochanlists"))]
+    #[cfg(all(not(feature = "nochanlists"), feature = "essentials"))]
     pub fn list_users(&self, chan: &str) -> Option<Vec<User>> {
         self.state.chanlists.read().get(&chan.to_owned()).cloned()
     }
 
-    #[cfg(feature = "nochanlists")]
+    #[cfg(any(feature = "nochanlists", not(feature = "essentials")))]
+    #[allow(missing_docs)]
     pub fn list_users(&self, _: &str) -> Option<Vec<User>> {
         None
     }
@@ -1078,47 +1244,59 @@ impl Client {
     /// client.send(Command::USER("user".to_owned(), "0".to_owned(), "name".to_owned())).unwrap();
     /// # }
     /// ```
-    pub fn send<M: Into<Message>>(&self, msg: M) -> error::Result<()> {
+    pub fn send<M: Into<Codec::MsgItem>>(&self, msg: M) -> error::Result<()> {
         self.state.send(msg)
     }
 
     /// Sends a CAP END, NICK and USER to identify.
     pub fn identify(&self) -> error::Result<()> {
         // Send a CAP END to signify that we're IRCv3-compliant (and to end negotiations!).
-        self.send(CAP(None, END, None, None))?;
+        self.send(<Codec as MessageCodec>::MsgItem::new_cap_end())?;
         if self.config().password() != "" {
-            self.send(PASS(self.config().password().to_owned()))?;
+            self.send(<Codec as MessageCodec>::MsgItem::new_pass(
+                self.config().password().to_owned(),
+            ))?;
         }
-        self.send(NICK(self.config().nickname()?.to_owned()))?;
-        self.send(USER(
+        self.send(<Codec as MessageCodec>::MsgItem::new_nick(
+            self.config().nickname()?.to_owned(),
+        ))?;
+        self.send(<Codec as MessageCodec>::MsgItem::new_user(
             self.config().username().to_owned(),
-            "0".to_owned(),
             self.config().real_name().to_owned(),
         ))?;
         Ok(())
     }
 
-    pub_state_base!();
-    pub_sender_base!();
+    pub_state_base!(<Codec as MessageCodec>::MsgItem);
+    pub_sender_base!(<Codec as MessageCodec>::MsgItem);
 }
 
 #[cfg(test)]
 mod test {
-    use std::{collections::HashMap, default::Default, thread, time::Duration};
+    use std::{default::Default, thread, time::Duration};
 
     use super::Client;
-    #[cfg(not(feature = "nochanlists"))]
+
+    #[cfg(all(not(feature = "nochanlists"), feature = "essentials"))]
     use crate::client::data::User;
+
     use crate::{
         client::data::Config,
-        error::Error,
         proto::{
             command::Command::{Raw, PRIVMSG},
-            ChannelMode, IrcCodec, Mode,
+            IrcCodec,
         },
     };
     use anyhow::Result;
-    use futures::prelude::*;
+    #[cfg(feature = "essentials")]
+    use {
+        crate::{
+            error::Error,
+            proto::{ChannelMode, Mode},
+        },
+        futures::prelude::*,
+        std::collections::HashMap,
+    };
 
     pub fn test_config() -> Config {
         Config {
@@ -1203,6 +1381,7 @@ mod test {
     }
 
     #[tokio::test]
+    #[cfg(feature = "essentials")]
     async fn handle_end_motd_with_chan_keys() -> Result<()> {
         let value = ":irc.test.net 376 test :End of /MOTD command\r\n";
         let mut client = Client::from_config(Config {
@@ -1226,6 +1405,7 @@ mod test {
     }
 
     #[tokio::test]
+    #[cfg(feature = "essentials")]
     async fn handle_end_motd_with_ghost() -> Result<()> {
         let value = ":irc.test.net 433 * test :Nickname is already in use.\r\n\
                      :irc.test.net 376 test2 :End of /MOTD command.\r\n";
@@ -1249,6 +1429,7 @@ mod test {
     }
 
     #[tokio::test]
+    #[cfg(feature = "essentials")]
     async fn handle_end_motd_with_ghost_seq() -> Result<()> {
         let value = ":irc.test.net 433 * test :Nickname is already in use.\r\n\
                      :irc.test.net 376 test2 :End of /MOTD command.\r\n";
@@ -1274,6 +1455,7 @@ mod test {
     }
 
     #[tokio::test]
+    #[cfg(feature = "essentials")]
     async fn handle_end_motd_with_umodes() -> Result<()> {
         let value = ":irc.test.net 376 test :End of /MOTD command.\r\n";
         let mut client = Client::from_config(Config {
@@ -1293,6 +1475,7 @@ mod test {
     }
 
     #[tokio::test]
+    #[cfg(feature = "essentials")]
     async fn nickname_in_use() -> Result<()> {
         let value = ":irc.test.net 433 * test :Nickname is already in use.\r\n";
         let mut client = Client::from_config(Config {
@@ -1306,6 +1489,7 @@ mod test {
     }
 
     #[tokio::test]
+    #[cfg(feature = "essentials")]
     async fn ran_out_of_nicknames() -> Result<()> {
         let value = ":irc.test.net 433 * test :Nickname is already in use.\r\n\
                      :irc.test.net 433 * test2 :Nickname is already in use.\r\n";
@@ -1369,7 +1553,7 @@ mod test {
     }
 
     #[tokio::test]
-    #[cfg(not(feature = "nochanlists"))]
+    #[cfg(all(not(feature = "nochanlists"), feature = "essentials"))]
     async fn channel_tracking_names() -> Result<()> {
         let value = ":irc.test.net 353 test = #test :test ~owner &admin\r\n";
         let mut client = Client::from_config(Config {
@@ -1383,7 +1567,7 @@ mod test {
     }
 
     #[tokio::test]
-    #[cfg(not(feature = "nochanlists"))]
+    #[cfg(all(not(feature = "nochanlists"), feature = "essentials"))]
     async fn channel_tracking_names_part() -> Result<()> {
         use crate::proto::command::Command::PART;
 
@@ -1405,7 +1589,7 @@ mod test {
     }
 
     #[tokio::test]
-    #[cfg(not(feature = "nochanlists"))]
+    #[cfg(all(not(feature = "nochanlists"), feature = "essentials"))]
     async fn user_tracking_names() -> Result<()> {
         let value = ":irc.test.net 353 test = #test :test ~owner &admin\r\n";
         let mut client = Client::from_config(Config {
@@ -1422,7 +1606,7 @@ mod test {
     }
 
     #[tokio::test]
-    #[cfg(not(feature = "nochanlists"))]
+    #[cfg(all(not(feature = "nochanlists"), feature = "essentials"))]
     async fn user_tracking_names_join() -> Result<()> {
         let value = ":irc.test.net 353 test = #test :test ~owner &admin\r\n\
                      :test2!test@test JOIN #test\r\n";
@@ -1445,7 +1629,7 @@ mod test {
     }
 
     #[tokio::test]
-    #[cfg(not(feature = "nochanlists"))]
+    #[cfg(all(not(feature = "nochanlists"), feature = "essentials"))]
     async fn user_tracking_names_kick() -> Result<()> {
         let value = ":irc.test.net 353 test = #test :test ~owner &admin\r\n\
                      :owner!test@test KICK #test test\r\n";
@@ -1463,7 +1647,7 @@ mod test {
     }
 
     #[tokio::test]
-    #[cfg(not(feature = "nochanlists"))]
+    #[cfg(all(not(feature = "nochanlists"), feature = "essentials"))]
     async fn user_tracking_names_part() -> Result<()> {
         let value = ":irc.test.net 353 test = #test :test ~owner &admin\r\n\
                      :owner!test@test PART #test\r\n";
@@ -1481,7 +1665,7 @@ mod test {
     }
 
     #[tokio::test]
-    #[cfg(not(feature = "nochanlists"))]
+    #[cfg(all(not(feature = "nochanlists"), feature = "essentials"))]
     async fn user_tracking_names_mode() -> Result<()> {
         let value = ":irc.test.net 353 test = #test :+test ~owner &admin\r\n\
                      :test!test@test MODE #test +o test\r\n";
@@ -1510,7 +1694,7 @@ mod test {
     }
 
     #[tokio::test]
-    #[cfg(feature = "nochanlists")]
+    #[cfg(any(feature = "nochanlists", not(feature = "essentials")))]
     async fn no_user_tracking() -> Result<()> {
         let value = ":irc.test.net 353 test = #test :test ~owner &admin\r\n";
         let mut client = Client::from_config(Config {
@@ -1718,6 +1902,7 @@ mod test {
     }
 
     #[tokio::test]
+    #[cfg(feature = "essentials")]
     async fn send_oper() -> Result<()> {
         let mut client = Client::from_config(test_config()).await?;
         client.send_oper("test", "test")?;
@@ -1727,6 +1912,7 @@ mod test {
     }
 
     #[tokio::test]
+    #[cfg(feature = "essentials")]
     async fn send_privmsg() -> Result<()> {
         let mut client = Client::from_config(test_config()).await?;
         client.send_privmsg("#test", "Hi, everybody!")?;
@@ -1739,6 +1925,7 @@ mod test {
     }
 
     #[tokio::test]
+    #[cfg(all(feature = "ctcp", feature = "essentials"))]
     async fn send_notice() -> Result<()> {
         let mut client = Client::from_config(test_config()).await?;
         client.send_notice("#test", "Hi, everybody!")?;
@@ -1751,6 +1938,7 @@ mod test {
     }
 
     #[tokio::test]
+    #[cfg(feature = "essentials")]
     async fn send_topic_no_topic() -> Result<()> {
         let mut client = Client::from_config(test_config()).await?;
         client.send_topic("#test", "")?;
@@ -1760,6 +1948,7 @@ mod test {
     }
 
     #[tokio::test]
+    #[cfg(feature = "essentials")]
     async fn send_topic() -> Result<()> {
         let mut client = Client::from_config(test_config()).await?;
         client.send_topic("#test", "Testing stuff.")?;
@@ -1772,6 +1961,7 @@ mod test {
     }
 
     #[tokio::test]
+    #[cfg(feature = "essentials")]
     async fn send_kill() -> Result<()> {
         let mut client = Client::from_config(test_config()).await?;
         client.send_kill("test", "Testing kills.")?;
@@ -1784,6 +1974,7 @@ mod test {
     }
 
     #[tokio::test]
+    #[cfg(feature = "essentials")]
     async fn send_kick_no_message() -> Result<()> {
         let mut client = Client::from_config(test_config()).await?;
         client.send_kick("#test", "test", "")?;
@@ -1793,6 +1984,7 @@ mod test {
     }
 
     #[tokio::test]
+    #[cfg(feature = "essentials")]
     async fn send_kick() -> Result<()> {
         let mut client = Client::from_config(test_config()).await?;
         client.send_kick("#test", "test", "Testing kicks.")?;
@@ -1805,6 +1997,7 @@ mod test {
     }
 
     #[tokio::test]
+    #[cfg(feature = "essentials")]
     async fn send_mode_no_modeparams() -> Result<()> {
         let mut client = Client::from_config(test_config()).await?;
         client.send_mode("#test", &[Mode::Plus(ChannelMode::InviteOnly, None)])?;
@@ -1814,6 +2007,7 @@ mod test {
     }
 
     #[tokio::test]
+    #[cfg(feature = "essentials")]
     async fn send_mode() -> Result<()> {
         let mut client = Client::from_config(test_config()).await?;
         client.send_mode(
@@ -1826,6 +2020,7 @@ mod test {
     }
 
     #[tokio::test]
+    #[cfg(feature = "essentials")]
     async fn send_samode_no_modeparams() -> Result<()> {
         let mut client = Client::from_config(test_config()).await?;
         client.send_samode("#test", "+i", "")?;
@@ -1835,6 +2030,7 @@ mod test {
     }
 
     #[tokio::test]
+    #[cfg(feature = "essentials")]
     async fn send_samode() -> Result<()> {
         let mut client = Client::from_config(test_config()).await?;
         client.send_samode("#test", "+o", "test")?;
@@ -1844,6 +2040,7 @@ mod test {
     }
 
     #[tokio::test]
+    #[cfg(feature = "essentials")]
     async fn send_sanick() -> Result<()> {
         let mut client = Client::from_config(test_config()).await?;
         client.send_sanick("test", "test2")?;
@@ -1853,6 +2050,7 @@ mod test {
     }
 
     #[tokio::test]
+    #[cfg(feature = "essentials")]
     async fn send_invite() -> Result<()> {
         let mut client = Client::from_config(test_config()).await?;
         client.send_invite("test", "#test")?;

--- a/src/client/mod.rs
+++ b/src/client/mod.rs
@@ -1350,35 +1350,45 @@ pub mod codec_tests {
         }
 
         pub async fn handle_end_motd() -> Result<()> {
-            let value = ":irc.test.net 376 test :End of /MOTD command.\r\n";
-            let mut client = Client::<Codec>::from_config_with_codec(Config {
-                mock_initial_value: Some(value.to_owned()),
-                ..test_config()
-            })
-            .await?;
-            client.stream()?.collect().await?;
-            assert_eq!(
-                &Self::get_client_value(client)[..],
-                "JOIN #test\r\nJOIN #test2\r\n"
-            );
+            let value_1 = ":irc.test.net 376 test :End of /MOTD command.\r\n";
+            let value_2 = ":*.freenode.net 376 pickles :End of message of the day.\r\n";
+            let value_3 = "@time=2022-11-01T00:11:42.987Z :testing.snowpoke.ink 376 irc-retriever-2 :End of message of the day.\r\n";
+
+            for value in [value_1, value_2, value_3] {
+                let mut client = Client::<Codec>::from_config_with_codec(Config {
+                    mock_initial_value: Some(value.to_owned()),
+                    ..test_config()
+                })
+                .await?;
+                client.stream()?.collect().await?;
+                assert_eq!(
+                    &Self::get_client_value(client)[..],
+                    "JOIN #test\r\nJOIN #test2\r\n"
+                );
+            }
             Ok(())
         }
 
         pub async fn handle_end_motd_with_nick_password() -> Result<()> {
-            let value = ":irc.test.net 376 test :End of /MOTD command.\r\n";
-            let mut client = Client::<Codec>::from_config_with_codec(Config {
-                mock_initial_value: Some(value.to_owned()),
-                nick_password: Some(format!("password")),
-                channels: vec![format!("#test"), format!("#test2")],
-                ..test_config()
-            })
-            .await?;
-            client.stream()?.collect().await?;
-            assert_eq!(
-                &Self::get_client_value(client)[..],
-                "NICKSERV IDENTIFY password\r\nJOIN #test\r\n\
+            let value_1 = ":irc.test.net 376 test :End of /MOTD command.\r\n";
+            let value_2 = ":*.freenode.net 376 pickles :End of message of the day.\r\n";
+            let value_3 = "@time=2022-11-01T00:11:42.987Z :testing.snowpoke.ink 376 irc-retriever-2 :End of message of the day.\r\n";
+
+            for value in [value_1, value_2, value_3] {
+                let mut client = Client::<Codec>::from_config_with_codec(Config {
+                    mock_initial_value: Some(value.to_owned()),
+                    nick_password: Some(format!("password")),
+                    channels: vec![format!("#test"), format!("#test2")],
+                    ..test_config()
+                })
+                .await?;
+                client.stream()?.collect().await?;
+                assert_eq!(
+                    &Self::get_client_value(client)[..],
+                    "NICKSERV IDENTIFY password\r\nJOIN #test\r\n\
              JOIN #test2\r\n"
-            );
+                );
+            }
             Ok(())
         }
 

--- a/src/client/transport.rs
+++ b/src/client/transport.rs
@@ -43,7 +43,7 @@ where
     Msg: InternalIrcMessageOutgoing + InternalIrcMessageIncoming,
 {
     /// Construct a new pinger helper.
-    pub fn new(tx: UnboundedSender<Msg>, config: &Config) -> Pinger<Msg> {
+    pub fn new(tx: UnboundedSender<Msg>, config: &Config) -> Self {
         let ping_time = Duration::from_secs(u64::from(config.ping_time()));
         let ping_timeout = Duration::from_secs(u64::from(config.ping_timeout()));
 
@@ -76,9 +76,7 @@ where
 
     /// Send a pong.
     fn send_pong(self: Pin<&mut Self>, data: &str) -> error::Result<()> {
-        self.project()
-            .tx
-            .send(Msg::new_pong(data.to_owned(), None))?;
+        self.project().tx.send(Msg::new_pong(data.to_owned()))?;
         Ok(())
     }
 
@@ -91,7 +89,7 @@ where
 
         let mut this = self.project();
 
-        this.tx.send(Msg::new_ping(data, None))?;
+        this.tx.send(Msg::new_ping(data))?;
 
         if this.ping_deadline.is_none() {
             let ping_deadline = time::sleep(*this.ping_timeout);

--- a/src/client/transport.rs
+++ b/src/client/transport.rs
@@ -168,6 +168,12 @@ where
     pub fn into_inner(self) -> Framed<T, Codec> {
         self.inner
     }
+
+    /// We don´t use the automatically created `project_ref` function, so this function exists to avoid a `dead_code` warning.
+    #[doc(hidden)]
+    pub fn _none(self: Pin<&Self>) {
+        let _ = self.project_ref();
+    }
 }
 
 impl<T, Codec> Stream for Transport<T, Codec>
@@ -288,6 +294,12 @@ where
     /// Gets a view of the logging for this transport.
     pub fn view(&self) -> LogView<Codec::MsgItem> {
         self.view.clone()
+    }
+
+    /// We don´t use the automatically created `project_ref` function, so this function exists to avoid a `dead_code` warning.
+    #[doc(hidden)]
+    pub fn _none(self: Pin<&Self>) {
+        let _ = self.project_ref();
     }
 }
 

--- a/src/client/transport.rs
+++ b/src/client/transport.rs
@@ -20,7 +20,10 @@ use tokio_util::codec::{Decoder, Encoder, Framed};
 
 use crate::{client::data::Config, error};
 
-use super::data::codec::{InternalIrcMessageIncoming, InternalIrcMessageOutgoing, MessageCodec};
+use super::{
+    data::codec::{InternalIrcMessageIncoming, InternalIrcMessageOutgoing, MessageCodec},
+    DefaultCodec,
+};
 
 /// Pinger-based futures helper.
 #[pin_project]
@@ -128,7 +131,7 @@ where
 /// implementation of `Connection` and ultimately `IrcServer`, and plays an important role in
 /// handling connection timeouts, message throttling, and ping response.
 #[pin_project]
-pub struct Transport<T, Codec>
+pub struct Transport<T, Codec = DefaultCodec>
 where
     Codec: MessageCodec,
 {
@@ -228,7 +231,7 @@ where
 
 /// A view of the logs from a particular `Logged` transport.
 #[derive(Clone, Debug)]
-pub struct LogView<Msg> {
+pub struct LogView<Msg = <DefaultCodec as MessageCodec>::MsgItem> {
     sent: Arc<RwLock<Vec<Msg>>>,
     received: Arc<RwLock<Vec<Msg>>>,
 }
@@ -248,7 +251,7 @@ impl<Msg> LogView<Msg> {
 /// A logged version of the `Transport` that records all sent and received messages.
 /// Note: this will introduce some performance overhead by cloning all messages.
 #[pin_project]
-pub struct Logged<T, Codec>
+pub struct Logged<T, Codec = DefaultCodec>
 where
     Codec: MessageCodec,
 {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -29,6 +29,7 @@
 //!
 //! let mut stream = client.stream()?;
 //!
+//! # #[cfg(feature = "essentials")]
 //! while let Some(message) = stream.next().await.transpose()? {
 //!     if let Command::PRIVMSG(channel, message) = message.command {
 //!         if message.contains(&*client.current_nickname()) {


### PR DESCRIPTION
At the moment, any IRC message is parsed as an entity of class `Message`:
```rust
pub struct Message {
    pub tags: Option<Vec<Tag>>,
    pub prefix: Option<Prefix>,
    pub command: Command,
}

```

However, some users may want to use adjusted versions of this type, or skip parsing altogether. It would be nice if this was possible without maintaining a custom fork of the crate.

So I generalized a lot of code relating to message interpretation and redefined the `Client` structure as this:
```rust
pub struct Client<Codec = DefaultCodec>
where
    Codec: MessageCodec,
    error::Error: From<<Codec as Decoder>::Error> + From<<Codec as Encoder<Codec::MsgItem>>::Error>,
    Codec::MsgItem: InternalIrcMessageOutgoing + InternalIrcMessageIncoming,
{
    state: Arc<ClientState<Codec>>,
    incoming: Option<SplitStream<Connection<Codec>>>,
    outgoing: Option<Outgoing<Codec>>,
    sender: Sender<Codec::MsgItem>,
}
```
This means that the new code is mostly backward-compatible, and if you want to use the crate with a custom IRC message parser, you can construct it as follows:
```rust
    let mut client = Client::<NoParseCodec>::from_config_with_codec(config).await?;
```

Of note, I have added a semver-breaking feature called `essentials`.
Basically, at this point I only wanted to write a minimum working example of a custom parser, so I gated a lot of features behind the `essentials` feature. If you remove this feature (as is required for the `NoParseCodec` to work), it removes all features from the client except for those strictly required to run an IRC client.

I'm currently successfully running a Twitch Chat scraper-like program using the `NoParseCodec` modification.

Btw it would be possible to adjust this code to be (mostly?) semver-compliant, but since the changes behind the scenes (and the potential for unexpected errors) are so big, I'm not sure if it's worth it.