### PR TITLE
Reconfigure chrono to remove CVE-2020-26235/RUSTSEC-2020-0159

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -41,7 +41,7 @@ tls-rust = ["tokio-rustls", "webpki-roots"]
 
 
 [dependencies]
-chrono = "0.4.0"
+chrono = { version = "0.4", default-features = false, features = ["clock", "std"] }
 encoding = "0.2.0"
 futures-util = { version = "0.3.0", default-features = false, features = ["alloc", "sink"] }
 irc-proto = { version = "0.15.0", path = "irc-proto" }


### PR DESCRIPTION
This is similiar to #238 but instead reconfigures chrono to not use time 0.1