### PR TITLE
Bump dependencies, set rust-version, and some more maintenance work

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,41 @@
+name: CI
+
+on:
+  pull_request: {}
+  push:
+    branches:
+      - develop
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        rust: ["1.60", stable]
+    steps:
+    - uses: actions/checkout@v3
+    - uses: dtolnay/rust-toolchain@master
+      with:
+        toolchain: ${{matrix.rust}}
+    - run: cargo build --workspace --all-targets
+    - run: cargo build --workspace --all-targets --no-default-features
+    - run: cargo build --workspace --all-targets --features tls-native
+    - run: cargo build --workspace --all-targets --features tls-rust
+    # runs all tests for all targets, including examples and benchmarks. Only on
+    # stable, since we don't care about tests running on MSRV.
+    - run: cargo test --workspace --all-targets
+      if: matrix.rust == 'stable'
+    # runs all documentation tests separately, since those are not picked up by
+    # `--all-targets`.
+    - run: cargo test --workspace --doc
+      if: matrix.rust == 'stable'
+
+  rustfmt:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v3
+    - uses: dtolnay/rust-toolchain@stable
+      with:
+        components: rustfmt
+    - run: cargo fmt --all --check

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,15 +1,16 @@
 [package]
 name = "irc"
 version = "0.15.0"
-description = "the irc crate – usable, async IRC for Rust "
 authors = ["Aaron Weiss <aweiss@hey.com>"]
+edition = "2018"
+rust-version = "1.60"
+description = "the irc crate – usable, async IRC for Rust "
+documentation = "https://docs.rs/irc/"
+readme = "README.md"
+repository = "https://github.com/aatxe/irc"
 license = "MPL-2.0"
 keywords = ["irc", "client", "thread-safe", "async", "tokio"]
 categories = ["asynchronous", "network-programming"]
-documentation = "https://docs.rs/irc/"
-repository = "https://github.com/aatxe/irc"
-readme = "README.md"
-edition = "2018"
 
 
 [badges]
@@ -37,46 +38,47 @@ yaml = ["yaml_config"]
 proxy = ["tokio-socks"]
 
 tls-native = ["native-tls", "tokio-native-tls"]
-tls-rust = ["tokio-rustls", "webpki-roots"]
+tls-rust = ["tokio-rustls", "webpki-roots", "rustls-pemfile"]
 
 
 [dependencies]
-chrono = { version = "0.4", default-features = false, features = ["clock", "std"] }
-encoding = "0.2.0"
-futures-util = { version = "0.3.0", default-features = false, features = ["alloc", "sink"] }
+chrono = { version = "0.4.24", default-features = false, features = ["clock", "std"] }
+encoding = "0.2.33"
+futures-util = { version = "0.3.28", default-features = false, features = ["alloc", "sink"] }
 irc-proto = { version = "0.15.0", path = "irc-proto" }
-log = "0.4.0"
-parking_lot = "0.11.0"
-thiserror = "1.0.0"
-pin-project = "1.0.2"
-tokio = { version = "1.0.0", features = ["net", "time", "sync"] }
-tokio-stream = "0.1.0"
-tokio-util = { version = "0.6.0", features = ["codec"] }
+log = "0.4.17"
+parking_lot = "0.12.1"
+thiserror = "1.0.40"
+pin-project = "1.0.12"
+tokio = { version = "1.27.0", features = ["net", "time", "sync"] }
+tokio-stream = "0.1.12"
+tokio-util = { version = "0.7.7", features = ["codec"] }
 
 # Feature - Config
-serde = { version = "1.0.0", optional = true }
-serde_derive = { version = "1.0.0", optional = true }
-serde_json = { version = "1.0.0", optional = true }
-serde_yaml = { version = "0.8.0", optional = true }
-toml = { version = "0.5.0", optional = true }
+serde = { version = "1.0.160", optional = true }
+serde_derive = { version = "1.0.160", optional = true }
+serde_json = { version = "1.0.95", optional = true }
+serde_yaml = { version = "0.9.21", optional = true }
+toml = { version = "0.7.3", optional = true }
 
 # Feature - Proxy
 tokio-socks = { version = "0.5.1", optional = true }
 
 # Feature - TLS
-native-tls = { version = "0.2.0", optional = true }
-tokio-rustls = { version = "0.22.0", features = ["dangerous_configuration"], optional = true }
-tokio-native-tls = { version = "0.3.0", optional = true }
-webpki-roots = { version = "0.20.0", optional = true }
+native-tls = { version = "0.2.11", optional = true }
+tokio-rustls = { version = "0.24.0", features = ["dangerous_configuration"], optional = true }
+rustls-pemfile = { version = "1.0.2", optional = true }
+tokio-native-tls = { version = "0.3.1", optional = true }
+webpki-roots = { version = "0.23.0", optional = true }
 
 
 [dev-dependencies]
-anyhow = "1.0.0"
-args = "2.0.0"
-env_logger = "0.7.0"
-futures = "0.3.0"
-getopts = "0.2.0"
-tokio = { version = "1.0.0", features = ["rt", "rt-multi-thread", "macros", "net", "time"] }
+anyhow = "1.0.70"
+args = "2.2.0"
+env_logger = "0.10.0"
+futures = "0.3.28"
+getopts = "0.2.21"
+tokio = { version = "1.27.0", features = ["rt", "rt-multi-thread", "macros", "net", "time"] }
 
 
 [[example]]

--- a/irc-proto/Cargo.toml
+++ b/irc-proto/Cargo.toml
@@ -1,14 +1,15 @@
 [package]
 name = "irc-proto"
 version = "0.15.0"
-description = "The IRC protocol distilled."
 authors = ["Aaron Weiss <aweiss@hey.com>"]
+edition = "2018"
+rust-version = "1.60"
+description = "The IRC protocol distilled."
+documentation = "https://docs.rs/irc-proto/"
+repository = "https://github.com/aatxe/irc"
 license = "MPL-2.0"
 keywords = ["irc", "protocol", "tokio"]
 categories = ["network-programming"]
-documentation = "https://docs.rs/irc-proto/"
-repository = "https://github.com/aatxe/irc"
-edition = "2018"
 
 [badges]
 travis-ci = { repository = "aatxe/irc" }
@@ -17,9 +18,9 @@ travis-ci = { repository = "aatxe/irc" }
 default = ["bytes", "tokio", "tokio-util"]
 
 [dependencies]
-encoding = "0.2.0"
-thiserror = "1.0.0"
+encoding = "0.2.33"
+thiserror = "1.0.40"
 
-bytes = { version = "1.0.0", optional = true }
-tokio = { version = "1.0.0", optional = true }
-tokio-util = { version = "0.6.0", features = ["codec"], optional = true }
+bytes = { version = "1.4.0", optional = true }
+tokio = { version = "1.27.0", optional = true }
+tokio-util = { version = "0.7.7", features = ["codec"], optional = true }

--- a/irc-proto/src/message.rs
+++ b/irc-proto/src/message.rs
@@ -550,13 +550,11 @@ mod test {
 
     #[test]
     fn to_message_with_colon_in_suffix() {
-        let msg = "PRIVMSG #test ::test"
-            .parse::<Message>()
-            .unwrap();
+        let msg = "PRIVMSG #test ::test".parse::<Message>().unwrap();
         let message = Message {
             tags: None,
             prefix: None,
-            command: PRIVMSG("#test".to_string(), ":test".to_string())
+            command: PRIVMSG("#test".to_string(), ":test".to_string()),
         };
         assert_eq!(msg, message);
     }

--- a/src/client/data/config.rs
+++ b/src/client/data/config.rs
@@ -523,7 +523,10 @@ impl Config {
     /// Gets whether or not to dangerously accept invalid certificates.
     /// This defaults to `false` when not specified.
     pub fn dangerously_accept_invalid_certs(&self) -> bool {
-        self.dangerously_accept_invalid_certs.as_ref().cloned().unwrap_or(false)
+        self.dangerously_accept_invalid_certs
+            .as_ref()
+            .cloned()
+            .unwrap_or(false)
     }
 
     /// Gets the path to the client authentication certificate in DER format if specified.

--- a/src/error.rs
+++ b/src/error.rs
@@ -5,9 +5,8 @@ use std::sync::mpsc::RecvError;
 
 use thiserror::Error;
 use tokio::sync::mpsc::error::{SendError, TrySendError};
-
 #[cfg(feature = "tls-rust")]
-use tokio_rustls::webpki::InvalidDNSNameError;
+use tokio_rustls::rustls::client::InvalidDnsNameError;
 
 use crate::proto::error::{MessageParseError, ProtocolError};
 
@@ -19,26 +18,51 @@ pub type Result<T, E = Error> = std::result::Result<T, E>;
 pub enum Error {
     /// An internal I/O error.
     #[error("an io error occurred")]
-    Io(#[source] IoError),
+    Io(
+        #[source]
+        #[from]
+        IoError,
+    ),
 
     /// An internal proxy error.
     #[cfg(feature = "proxy")]
     #[error("a proxy error occurred")]
-    Proxy(tokio_socks::Error),
+    Proxy(#[from] tokio_socks::Error),
 
     /// An internal TLS error.
-    #[cfg(feature = "tls-native")]
+    #[cfg(all(feature = "tls-native", not(feature = "tls-rust")))]
     #[error("a TLS error occurred")]
-    Tls(#[source] native_tls::Error),
+    Tls(
+        #[source]
+        #[from]
+        native_tls::Error,
+    ),
 
-    /// An internal DNS error.
+    /// An internal TLS error.
     #[cfg(feature = "tls-rust")]
-    #[error("a DNS error occurred")]
-    Dns(#[source] InvalidDNSNameError),
+    #[error("a TLS error occurred")]
+    Tls(
+        #[source]
+        #[from]
+        tokio_rustls::rustls::Error,
+    ),
+
+    /// An invalid DNS name was specified.
+    #[cfg(feature = "tls-rust")]
+    #[error("invalid DNS name")]
+    InvalidDnsNameError(
+        #[source]
+        #[from]
+        InvalidDnsNameError,
+    ),
 
     /// An internal synchronous channel closed.
     #[error("a sync channel closed")]
-    SyncChannelClosed(#[source] RecvError),
+    SyncChannelClosed(
+        #[source]
+        #[from]
+        RecvError,
+    ),
 
     /// An internal asynchronous channel closed.
     #[error("an async channel closed")]
@@ -173,39 +197,6 @@ impl From<ProtocolError> for Error {
                 Error::InvalidMessage { string, cause }
             }
         }
-    }
-}
-
-impl From<IoError> for Error {
-    fn from(e: IoError) -> Error {
-        Error::Io(e)
-    }
-}
-
-#[cfg(feature = "proxy")]
-impl From<tokio_socks::Error> for Error {
-    fn from(e: tokio_socks::Error) -> Error {
-        Error::Proxy(e)
-    }
-}
-
-#[cfg(feature = "tls-native")]
-impl From<native_tls::Error> for Error {
-    fn from(e: native_tls::Error) -> Error {
-        Error::Tls(e)
-    }
-}
-
-#[cfg(feature = "tls-rust")]
-impl From<InvalidDNSNameError> for Error {
-    fn from(e: InvalidDNSNameError) -> Error {
-        Error::Dns(e)
-    }
-}
-
-impl From<RecvError> for Error {
-    fn from(e: RecvError) -> Error {
-        Error::SyncChannelClosed(e)
     }
 }
 


### PR DESCRIPTION
Reason for this change is that I noticed that the `irc` crate was the sole cause in my dependency graph for pulling in some old dependencies (`parking_lot` among others). Some dependencies had CVEs specified for versions which were inside of their minimal ranges. So I went ahead and ran a `cargo upgrade --workspace` here.

I used a tool which tried to build and detect the MSRV and updated rust-version. It also sorted the fields, as they are specified in the Cargo documentation. Hope this i OK, otherwise I'll pull it back.

Since [features need to be additive](https://doc.rust-lang.org/cargo/reference/features.html#feature-unification), I've made it so that if both `tls-rust` and `tls-native` are activated, only `tls-rust` will be used. If you want this flipped, please tell me.

Finally I've added a Github workflow file, which performs most checks (including testing for MSRV). But I haven't ported any integration tests yet. So if you want to keep running them on Travis that is OK by me. [You can see the run here](https://github.com/udoprog/irc/actions).