### PR TITLE
Provide encapsulated Tls error information

### DIFF
--- a/src/error.rs
+++ b/src/error.rs
@@ -31,7 +31,7 @@ pub enum Error {
 
     /// An internal TLS error.
     #[cfg(all(feature = "tls-native", not(feature = "tls-rust")))]
-    #[error("a TLS error occurred")]
+    #[error("a TLS error occurred: {0}")]
     Tls(
         #[source]
         #[from]


### PR DESCRIPTION
When `.to_string()` is invoked on a the crate-wide Error enum, the error message using #[error("...")] is displayed. Some of those wrapped internal enums also contain, possibly more helpful, error messages.  This will include the string gathered by `.to_string()` from the encapsulated enum in the main error message.

See also
https://github.com/squidowl/halloy/pull/143