### PR TITLE
CertFP: The file must be a PKCS #12 archive

### DIFF
--- a/src/client/data/config.rs
+++ b/src/client/data/config.rs
@@ -129,7 +129,8 @@ pub struct Config {
     #[cfg(any(feature = "tls-native", feature = "tls-rust"))]
     #[cfg_attr(feature = "serde", serde(skip_serializing_if = "Option::is_none"))]
     pub cert_path: Option<String>,
-    /// The path to a TLS certificate to use for CertFP client authentication in DER format.
+    /// The path to a TLS certificate to use for CertFP client authentication in a DER-formatted
+    /// PKCS #12 archive.
     #[cfg(any(feature = "tls-native", feature = "tls-rust"))]
     #[cfg_attr(feature = "serde", serde(skip_serializing_if = "Option::is_none"))]
     pub client_cert_path: Option<String>,


### PR DESCRIPTION
While this archive is indeed DER-formatted, in contrast to `cert_path`, a regular DER file created from some certificate/key PEM file won't work:

```
openssl x509 -outform der -in foo.pem -out foo.der
```

This will result in the following OpenSSL error through tls-native error:

```
error:068000A8:asn1 encoding routines:asn1_check_tlen:wrong tag:crypto/asn1/tasn_dec.c:1188:
error:0688010A:asn1 encoding routines:asn1_d2i_ex_primitive:nested asn1
error:crypto/asn1/tasn_dec.c:752:
error:0688010A:asn1 encoding routines:asn1_template_noexp_d2i:nested asn1
error:crypto/asn1/tasn_dec.c:685:Field=version, Type=PKCS12
```

Instead, a PKCS #12 archive must be created like so:

```
openssl pkcs12 -export -out foo.p12 -inkey fookey.pem -in foocert.pem
```

If the PEM file contains both the private key and the certificate, the same file can be passed to `openssl` twice.

Also compare the documentation for `from_pkcs12` to `from_der` in native-tls, as used in the `new_secured_transport` function:

https://docs.rs/native-tls/0.2.11/native_tls/struct.Identity.html#method.from_pkcs12