### PR TITLE
Add SASL PLAIN authentication support

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -43,6 +43,7 @@ tls-rust = ["tokio-rustls", "webpki-roots", "rustls-pemfile"]
 
 [dependencies]
 chrono = { version = "0.4.24", default-features = false, features = ["clock", "std"] }
+base64ct = { version = "1.6.0", features = ["std"] }
 encoding = "0.2.33"
 futures-util = { version = "0.3.30", default-features = false, features = ["alloc", "sink"] }
 irc-proto = { version = "1.0.0", path = "irc-proto" }

--- a/src/client/data/client_config.json
+++ b/src/client/data/client_config.json
@@ -6,6 +6,7 @@
   "username": "test",
   "realname": "test",
   "password": "",
+  "sasl": "none",
   "server": "irc.test.net",
   "port": 6667,
   "encoding": "UTF-8",

--- a/src/client/data/client_config.toml
+++ b/src/client/data/client_config.toml
@@ -5,6 +5,7 @@ realname = "test"
 server = "irc.test.net"
 port = 6667
 password = ""
+sasl = "none"
 encoding = "UTF-8"
 channels = ["#test", "#test2"]
 umodes = "+BR"

--- a/src/client/data/client_config.yaml
+++ b/src/client/data/client_config.yaml
@@ -7,6 +7,7 @@ realname: test
 server: irc.test.net
 port: 6667
 password: ""
+sasl: none
 encoding: UTF-8
 channels:
   - "#test"

--- a/src/client/data/mod.rs
+++ b/src/client/data/mod.rs
@@ -8,4 +8,5 @@ pub use crate::client::data::user::{AccessLevel, User};
 pub mod config;
 #[cfg(feature = "proxy")]
 pub mod proxy;
+pub mod sasl;
 pub mod user;

--- a/src/client/data/sasl.rs
+++ b/src/client/data/sasl.rs
@@ -1,0 +1,31 @@
+//! SASL authentication support
+//!
+//! ```
+//! use irc::client::prelude::Config;
+//! use irc::client::data::sasl::SASLMode;
+//!
+//! # fn main() {
+//! let config = Config {
+//!     nickname: Some("test".to_owned()),
+//!     server: Some("irc.example.com".to_owned()),
+//!     login: Some("server_login".to_owned()),
+//!     password: Some("server_password".to_owned()),
+//!     sasl: Some(SASLMode::Plain),
+//!     ..Config::default()
+//! };
+//! # }
+//! ```
+#[cfg(feature = "serde")]
+use serde::{Deserialize, Serialize};
+
+/// An enum which defines which type of SASL authentication mode should be used.
+#[derive(Clone, PartialEq, Debug)]
+#[non_exhaustive]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
+#[cfg_attr(feature = "serde", serde(rename_all = "lowercase"))]
+pub enum SASLMode {
+    /// Do not use any SASL auth
+    None,
+    /// Authenticate in SASL PLAIN mode
+    Plain,
+}

--- a/src/error.rs
+++ b/src/error.rs
@@ -123,6 +123,14 @@ pub enum Error {
     /// Stream has already been configured.
     #[error("stream has already been configured")]
     StreamAlreadyConfigured,
+
+    /// Login contains null bytes
+    #[error("Login contains null '\\0' byte, which makes SASL plain authentication impossible")]
+    LoginContainsNullByte,
+
+    /// Password contains null bytes
+    #[error("Password contains null '\\0' byte, which makes SASL plain authentication impossible")]
+    PasswordContainsNullByte,
 }
 
 /// Errors that occur with configurations.


### PR DESCRIPTION
Add a new config option "sasl", which can be set to "none" or "plain". In none, behavior does not change and will be the same as, using the password config option with PASS.
When plain is selected, the new "login" option will be coupled with the existing "password" option to connect to the server with SASL PLAIN mode.

The implementation currently does blind SASL login. It does not check if the server supports sasl, sasl plain, and does not verify login errors, etc.
For simplicity, I chose not to add a state-machine that would handle verifying SASL support, login success, etc. It would need a different, async API for that, and I thought it would be overkill. It has been tested successfully with libera.chat.

This PR adds a new dependency "base64ct", a base64 crate by the RustCrypto project with no dependency (here std is enabled though); if you prefer I can add an ad-hoc licence compatible base64 encode function. I'd prefer not to guard the SASL support behind a feature if possible.

Tests were added and doc has been updated.

Related to #166