### PR TITLE
Update tokio-rustls dependency

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -66,10 +66,10 @@ tokio-socks = { version = "0.5.1", optional = true }
 
 # Feature - TLS
 native-tls = { version = "0.2.11", optional = true }
-tokio-rustls = { version = "0.24.0", features = ["dangerous_configuration"], optional = true }
-rustls-pemfile = { version = "1.0.2", optional = true }
+tokio-rustls = { version = "0.26.0", optional = true }
+rustls-pemfile = { version = "2", optional = true }
 tokio-native-tls = { version = "0.3.1", optional = true }
-webpki-roots = { version = "0.23.0", optional = true }
+webpki-roots = { version = "0.26.0", optional = true }
 
 
 [dev-dependencies]

--- a/src/error.rs
+++ b/src/error.rs
@@ -6,7 +6,7 @@ use std::sync::mpsc::RecvError;
 use thiserror::Error;
 use tokio::sync::mpsc::error::{SendError, TrySendError};
 #[cfg(feature = "tls-rust")]
-use tokio_rustls::rustls::client::InvalidDnsNameError;
+use tokio_rustls::rustls::pki_types::InvalidDnsNameError;
 
 use crate::proto::error::{MessageParseError, ProtocolError};
 


### PR DESCRIPTION
I've attempted to port this crate to the latest version of rustls. There are two things I'm not 100% sure about:

- My changes to DangerousAcceptAllVerifier
- As far as I can tell `config.client_cert_pass()` is being used as a private key DER, but according to the docs it's supposed to be a private key password (e.g. pkcs8)

(cc @cpu, in case you care about this) :)