### PR TITLE
Do not separate mode flags with spaces when stringifying MODE commands

### DIFF
--- a/irc-proto/src/command.rs
+++ b/irc-proto/src/command.rs
@@ -227,15 +227,13 @@ impl<'a> From<&'a Command> for String {
             Command::NICK(ref n) => stringify("NICK", &[n]),
             Command::USER(ref u, ref m, ref r) => stringify("USER", &[u, m, "*", r]),
             Command::OPER(ref u, ref p) => stringify("OPER", &[u, p]),
-            Command::UserMODE(ref u, ref m) => format!(
-                "MODE {}{}",
-                u,
-                m.iter().fold(String::new(), |mut acc, mode| {
-                    acc.push(' ');
-                    acc.push_str(&mode.to_string());
+            Command::UserMODE(ref u, ref m) => {
+                // User modes never have arguments.
+                m.iter().fold(format!("MODE {u} "), |mut acc, m| {
+                    acc.push_str(&m.flag());
                     acc
                 })
-            ),
+            }
             Command::SERVICE(ref nick, ref r0, ref dist, ref typ, ref r1, ref info) => {
                 stringify("SERVICE", &[nick, r0, dist, typ, r1, info])
             }
@@ -248,15 +246,17 @@ impl<'a> From<&'a Command> for String {
             Command::JOIN(ref c, None, None) => stringify("JOIN", &[c]),
             Command::PART(ref c, Some(ref m)) => stringify("PART", &[c, m]),
             Command::PART(ref c, None) => stringify("PART", &[c]),
-            Command::ChannelMODE(ref u, ref m) => format!(
-                "MODE {}{}",
-                u,
-                m.iter().fold(String::new(), |mut acc, mode| {
+            Command::ChannelMODE(ref c, ref m) => {
+                let cmd = m.iter().fold(format!("MODE {c} "), |mut acc, m| {
+                    acc.push_str(&m.flag());
+                    acc
+                });
+                m.iter().filter_map(|m| m.arg()).fold(cmd, |mut acc, arg| {
                     acc.push(' ');
-                    acc.push_str(&mode.to_string());
+                    acc.push_str(arg);
                     acc
                 })
-            ),
+            }
             Command::TOPIC(ref c, Some(ref t)) => stringify("TOPIC", &[c, t]),
             Command::TOPIC(ref c, None) => stringify("TOPIC", &[c]),
             Command::NAMES(Some(ref c), Some(ref t)) => stringify("NAMES", &[c, t]),

--- a/irc-proto/src/mode.rs
+++ b/irc-proto/src/mode.rs
@@ -238,6 +238,24 @@ where
     pub fn no_prefix(inner: T) -> Mode<T> {
         Mode::NoPrefix(inner)
     }
+
+    /// Gets the mode flag associated with this mode with a + or - prefix as needed.
+    pub fn flag(&self) -> String {
+        match self {
+            Mode::Plus(mode, _) => format!("+{}", mode),
+            Mode::Minus(mode, _) => format!("-{}", mode),
+            Mode::NoPrefix(mode) => mode.to_string(),
+        }
+    }
+
+    /// Gets the arg associated with this mode, if any. Only some channel modes support arguments,
+    /// e.g. b (ban) or o (oper).
+    pub fn arg(&self) -> Option<&str> {
+        match self {
+            Mode::Plus(_, arg) | Mode::Minus(_, arg) => arg.as_deref(),
+            _ => None,
+        }
+    }
 }
 
 impl<T> fmt::Display for Mode<T>
@@ -246,11 +264,10 @@ where
 {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         match *self {
-            Mode::Plus(ref mode, Some(ref arg)) => write!(f, "+{} {}", mode, arg),
-            Mode::Minus(ref mode, Some(ref arg)) => write!(f, "-{} {}", mode, arg),
-            Mode::Plus(ref mode, None) => write!(f, "+{}", mode),
-            Mode::Minus(ref mode, None) => write!(f, "-{}", mode),
-            Mode::NoPrefix(ref mode) => write!(f, "{}", mode),
+            Mode::Plus(_, Some(ref arg)) | Mode::Minus(_, Some(ref arg)) => {
+                write!(f, "{} {}", self.flag(), arg)
+            }
+            _ => write!(f, "{}", self.flag()),
         }
     }
 }


### PR DESCRIPTION
RFC2812 specifies two parameters (<nickname> <modestring>) for the user mode message, but irc-proto currently sends each mode as a separate argument. At least some IRC servers ignore anything other than the first two parameters, causing user mode changes past the first to be dropped.