### PR TITLE
feat(ircv3): add simple internal batch processing

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,9 +24,10 @@ members = [ "./", "irc-proto/" ]
 
 
 [features]
-default = ["ctcp", "tls-native", "channel-lists", "toml_config"]
+default = ["ctcp", "tls-native", "channel-lists", "batch", "toml_config"]
 ctcp = []
 channel-lists = []
+batch = []
 
 json_config = ["serde", "serde/derive", "serde_derive", "serde_json"]
 toml_config = ["serde", "serde/derive", "serde_derive", "toml"]

--- a/src/error.rs
+++ b/src/error.rs
@@ -123,6 +123,14 @@ pub enum Error {
     /// Stream has already been configured.
     #[error("stream has already been configured")]
     StreamAlreadyConfigured,
+
+    /// A end of batch message was sent after a pending batch was removed from the inflight list
+    #[error("batch disappeared before end of batch was processed")]
+    BatchDisappearedBeforeEndOfBatchProcessed,
+
+    /// A new batch was started with the same reference tag
+    #[error("batch {} already exists but a new batch request with the same tag was sent", .0)]
+    BatchAlreadyExists(String),
 }
 
 /// Errors that occur with configurations.


### PR DESCRIPTION
The BATCH feature is a form of a server-suggested message processing delays.

To implement this, we can record all inflight batches, handle start/end in handle_batch and collect all pending messages in the entrypoint of the message handler as long as they have a correct batch id.

TODO:

- [ ] Cap negotiations
- [ ] Better error handling
- [ ] More debug tracing