### PR TITLE
Fix gating of tokio feature

### DIFF
--- a/irc-proto/Cargo.toml
+++ b/irc-proto/Cargo.toml
@@ -15,7 +15,8 @@ categories = ["network-programming"]
 travis-ci = { repository = "aatxe/irc" }
 
 [features]
-default = ["bytes", "tokio", "tokio-util"]
+default = ["tokio"]
+tokio = ["bytes", "dep:tokio", "tokio-util"]
 
 [dependencies]
 encoding = "0.2.33"


### PR DESCRIPTION
Debian tooling noticed the crate doesn't build with:
```
cargo check --no-default-features -F tokio
```
because `src/irc.rs` is gated like this:
```rust
#[cfg(feature = "tokio")]
pub mod irc;
```
but contains imports like this:
```rust
use bytes::BytesMut;
use tokio_util::codec::{Decoder, Encoder};
```
With this patch `tokio` becomes a feature that enables the relevant other dependencies. :)