### PR TITLE
make encoding optional

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,7 +24,7 @@ members = [ "./", "irc-proto/" ]
 
 
 [features]
-default = ["ctcp", "tls-native", "channel-lists", "toml_config"]
+default = ["ctcp", "tls-native", "channel-lists", "toml_config", "encoding"]
 ctcp = []
 channel-lists = []
 
@@ -39,11 +39,11 @@ proxy = ["tokio-socks"]
 
 tls-native = ["native-tls", "tokio-native-tls"]
 tls-rust = ["tokio-rustls", "webpki-roots", "rustls-pemfile"]
-
+encoding = ["dep:encoding", "irc-proto/encoding"]
 
 [dependencies]
 chrono = { version = "0.4.24", default-features = false, features = ["clock", "std"] }
-encoding = "0.2.33"
+encoding = { version = "0.2.33", optional = true }
 futures-util = { version = "0.3.30", default-features = false, features = ["alloc", "sink"] }
 irc-proto = { version = "1.0.0", path = "irc-proto" }
 log = "0.4.21"

--- a/irc-proto/Cargo.toml
+++ b/irc-proto/Cargo.toml
@@ -18,7 +18,7 @@ travis-ci = { repository = "aatxe/irc" }
 default = ["bytes", "tokio", "tokio-util"]
 
 [dependencies]
-encoding = "0.2.33"
+encoding = { version = "0.2.33", optional = true }
 thiserror = "1.0.40"
 
 bytes = { version = "1.4.0", optional = true }

--- a/irc-proto/src/line.rs
+++ b/irc-proto/src/line.rs
@@ -3,7 +3,9 @@
 use std::io;
 
 use bytes::BytesMut;
+#[cfg(feature = "encoding")]
 use encoding::label::encoding_from_whatwg_label;
+#[cfg(feature = "encoding")]
 use encoding::{DecoderTrap, EncoderTrap, EncodingRef};
 use tokio_util::codec::{Decoder, Encoder};
 
@@ -11,6 +13,7 @@ use crate::error;
 
 /// A line-based codec parameterized by an encoding.
 pub struct LineCodec {
+    #[cfg(feature = "encoding")]
     encoding: EncodingRef,
     next_index: usize,
 }
@@ -18,18 +21,19 @@ pub struct LineCodec {
 impl LineCodec {
     /// Creates a new instance of LineCodec from the specified encoding.
     pub fn new(label: &str) -> error::Result<LineCodec> {
-        encoding_from_whatwg_label(label)
-            .map(|enc| LineCodec {
-                encoding: enc,
-                next_index: 0,
-            })
-            .ok_or_else(|| {
-                io::Error::new(
-                    io::ErrorKind::InvalidInput,
-                    &format!("Attempted to use unknown codec {}.", label)[..],
-                )
-                .into()
-            })
+        Ok(LineCodec {
+            #[cfg(feature = "encoding")]
+            encoding: match encoding_from_whatwg_label(label) {
+                Some(x) => x,
+                None => {
+                    return Err(error::ProtocolError::Io(io::Error::new(
+                        io::ErrorKind::InvalidInput,
+                        &format!("Attempted to use unknown codec {}.", label)[..],
+                    )));
+                }
+            },
+            next_index: 0,
+        })
     }
 }
 
@@ -45,14 +49,29 @@ impl Decoder for LineCodec {
             // Set the search start index back to 0 since we found a newline.
             self.next_index = 0;
 
-            // Decode the line using the codec's encoding.
-            match self.encoding.decode(line.as_ref(), DecoderTrap::Replace) {
-                Ok(data) => Ok(Some(data)),
-                Err(data) => Err(io::Error::new(
-                    io::ErrorKind::InvalidInput,
-                    &format!("Failed to decode {} as {}.", data, self.encoding.name())[..],
-                )
-                .into()),
+            #[cfg(feature = "encoding")]
+            {
+                // Decode the line using the codec's encoding.
+                match self.encoding.decode(line.as_ref(), DecoderTrap::Replace) {
+                    Ok(data) => Ok(Some(data)),
+                    Err(data) => Err(io::Error::new(
+                        io::ErrorKind::InvalidInput,
+                        &format!("Failed to decode {} as {}.", data, self.encoding.name())[..],
+                    )
+                    .into()),
+                }
+            }
+
+            #[cfg(not(feature = "encoding"))]
+            {
+                match String::from_utf8(line.to_vec()) {
+                    Ok(data) => Ok(Some(data)),
+                    Err(data) => Err(io::Error::new(
+                        io::ErrorKind::InvalidInput,
+                        &format!("Failed to decode {} as UTF-8.", data)[..],
+                    )
+                    .into()),
+                }
             }
         } else {
             // Set the search start index to the current length since we know that none of the
@@ -67,20 +86,27 @@ impl Encoder<String> for LineCodec {
     type Error = error::ProtocolError;
 
     fn encode(&mut self, msg: String, dst: &mut BytesMut) -> error::Result<()> {
-        // Encode the message using the codec's encoding.
-        let data: error::Result<Vec<u8>> = self
-            .encoding
-            .encode(&msg, EncoderTrap::Replace)
-            .map_err(|data| {
-                io::Error::new(
-                    io::ErrorKind::InvalidInput,
-                    &format!("Failed to encode {} as {}.", data, self.encoding.name())[..],
-                )
-                .into()
-            });
+        #[cfg(feature = "encoding")]
+        {
+            // Encode the message using the codec's encoding.
+            let data: error::Result<Vec<u8>> = self
+                .encoding
+                .encode(&msg, EncoderTrap::Replace)
+                .map_err(|data| {
+                    io::Error::new(
+                        io::ErrorKind::InvalidInput,
+                        &format!("Failed to encode {} as {}.", data, self.encoding.name())[..],
+                    )
+                    .into()
+                });
+            // Write the encoded message to the output buffer.
+            dst.extend(&data?);
+        }
 
-        // Write the encoded message to the output buffer.
-        dst.extend(&data?);
+        #[cfg(not(feature = "encoding"))]
+        {
+            dst.extend(msg.into_bytes());
+        }
 
         Ok(())
     }


### PR DESCRIPTION
Getting rid of the `encoding` dependency immediately eliminated 500KiB from my end binary. It is absolutely unnecessary given that UTF-8 is all the rage. But still, let's be conservative and to prevent breaking changes, let that be enabled by default. User who doesn't want `encoding` can use `default-features = false` and then add the features up at that point.