### PR TITLE
Add native-certs support

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -38,7 +38,7 @@ yaml = ["yaml_config"]
 proxy = ["tokio-socks"]
 
 tls-native = ["native-tls", "tokio-native-tls"]
-tls-rust = ["tokio-rustls", "webpki-roots", "rustls-pemfile"]
+tls-rust = ["rustls-native-certs", "rustls-pemfile", "tokio-rustls", "webpki-roots"]
 encoding = ["dep:encoding", "irc-proto/encoding"]
 
 [dependencies]
@@ -66,9 +66,10 @@ tokio-socks = { version = "0.5.1", optional = true }
 
 # Feature - TLS
 native-tls = { version = "0.2.11", optional = true }
-tokio-rustls = { version = "0.26.0", optional = true }
-rustls-pemfile = { version = "2", optional = true }
 tokio-native-tls = { version = "0.3.1", optional = true }
+rustls-native-certs = { version = "0.8", optional = true }
+rustls-pemfile = { version = "2", optional = true }
+tokio-rustls = { version = "0.26.0", optional = true }
 webpki-roots = { version = "0.26.0", optional = true }
 
 


### PR DESCRIPTION
I've packaged the irc crate for Debian yesterday, and the policy forbids use of the `webpki-roots` crate, because it duplicates the official certificate store. I patched it to rustls-native-certs, this adds some of the code upstream so I only need to remove the "webpki-roots" crate from Cargo.toml with a downstream patch and everything else "falls into place". :)

It also adds support for `rustls-native-certs`, but won't cause a failure if it errors.