### PR TITLE
Replace serde_derive with serde/derive

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,9 +28,9 @@ default = ["ctcp", "tls-native", "channel-lists", "toml_config", "encoding"]
 ctcp = []
 channel-lists = []
 
-json_config = ["serde", "serde/derive", "serde_derive", "serde_json"]
-toml_config = ["serde", "serde/derive", "serde_derive", "toml"]
-yaml_config = ["serde", "serde/derive", "serde_derive", "serde_yaml"]
+json_config = ["serde", "serde_json"]
+toml_config = ["serde", "toml"]
+yaml_config = ["serde", "serde_yaml"]
 # Temporary transitionary features
 json = ["json_config"]
 yaml = ["yaml_config"]
@@ -55,8 +55,7 @@ tokio-stream = "0.1.12"
 tokio-util = { version = "0.7.7", features = ["codec"] }
 
 # Feature - Config
-serde = { version = "1.0.160", optional = true }
-serde_derive = { version = "1.0.160", optional = true }
+serde = { version = "1.0.160", features = ["derive"], optional = true }
 serde_json = { version = "1.0.95", optional = true }
 serde_yaml = { version = "0.9.21", optional = true }
 toml = { version = "0.7.3", optional = true }


### PR DESCRIPTION
Debian autopkgtests is very eager in trying to find all possible combinations, and tries to build the crate with `cargo check --no-default-features --features serde`, which currently doesn't work.

I'm patching this downstream, this change removes the need for that patch.

In theory this is a breaking change, in case somebody uses (for whatever reason):

```toml
irc = { version = "1", features = ["toml_config", "serde_derive"] }
```

this would not work anymore, you could work around this by having a feature named "serde_derive" that does nothing:

```toml
[features]
serde_derive = []
```