### PR TITLE
Allow marking ClientStream as terminated

### DIFF
--- a/src/client/mod.rs
+++ b/src/client/mod.rs
@@ -437,6 +437,8 @@ pub struct ClientStream {
     stream: SplitStream<Connection>,
     // In case the client stream also handles outgoing messages.
     outgoing: Option<Outgoing>,
+
+    terminated: bool,
 }
 
 impl ClientStream {
@@ -453,11 +455,16 @@ impl ClientStream {
 
         Ok(output)
     }
+
+    /// marks this stream as terminated
+    pub fn set_terminated(&mut self) {
+        self.terminated = true;
+    }
 }
 
 impl FusedStream for ClientStream {
     fn is_terminated(&self) -> bool {
-        false
+        self.terminated
     }
 }
 
@@ -992,6 +999,7 @@ impl Client {
             state: Arc::clone(&self.state),
             stream,
             outgoing: self.outgoing.take(),
+            terminated: false,
         })
     }
 


### PR DESCRIPTION
I'm not sure if this is the right way to go about things  but it's how my current code is designed and it has been working fine for me.

That way streams can be individually set terminated manually to avoid panics when using `select_next_some()`.
Along with `select!` and `futures::future::select_all`

Example scenario:
- A client receives `PingTimeout`
- sends `QUIT`
- sets the stream as terminated

There might be a better way to react to timeouts but having the ability to set terminated should still be useful.