### PR TITLE
Replace unmaintained rustls-pemfile with rustls-pki-types PemObject

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -40,7 +40,6 @@ proxy = ["tokio-socks"]
 tls-native = ["native-tls", "tokio-native-tls"]
 tls-rust = [
     "rustls-native-certs",
-    "rustls-pemfile",
     "tokio-rustls",
     "webpki-roots",
 ]
@@ -78,7 +77,6 @@ tokio-socks = { version = "0.5.1", optional = true }
 native-tls = { version = "0.2.11", optional = true }
 tokio-native-tls = { version = "0.3.1", optional = true }
 rustls-native-certs = { version = "0.8", optional = true }
-rustls-pemfile = { version = "2", optional = true }
 tokio-rustls = { version = "0.26.0", optional = true }
 webpki-roots = { version = "0.26.0", optional = true }
 

--- a/src/client/conn.rs
+++ b/src/client/conn.rs
@@ -28,8 +28,7 @@ use tokio_native_tls::{self, TlsStream};
 #[cfg(feature = "tls-rust")]
 use std::{
     convert::TryFrom,
-    fs::File,
-    io::{BufReader, Error, ErrorKind},
+    io::{Error, ErrorKind},
     sync::Arc,
 };
 #[cfg(feature = "tls-rust")]
@@ -39,7 +38,8 @@ use tokio_rustls::{
     rustls::client::danger::{ServerCertVerified, ServerCertVerifier},
     rustls::crypto::{verify_tls12_signature, verify_tls13_signature, CryptoProvider},
     rustls::pki_types::{
-        CertificateDer as Certificate, PrivateKeyDer as PrivateKey, ServerName, UnixTime,
+        pem::PemObject, CertificateDer as Certificate, PrivateKeyDer as PrivateKey, ServerName,
+        UnixTime,
     },
     rustls::{self, ClientConfig, RootCertStore},
     TlsConnector,
@@ -287,20 +287,21 @@ impl Connection {
         }
 
         let client_auth = if let Some(client_cert_path) = config.client_cert_path() {
-            if let Ok(file) = File::open(client_cert_path) {
-                let client_cert_data =
-                    rustls_pemfile::certs(&mut BufReader::new(file)).collect::<Result<_, _>>()?;
+            if let Ok(cert_iter) = Certificate::pem_file_iter(client_cert_path) {
+                let client_cert_data = cert_iter
+                    .collect::<Result<Vec<_>, _>>()
+                    .map_err(|e| Error::new(ErrorKind::InvalidData, e.to_string()))?;
 
                 let client_cert_pass = config.client_cert_pass();
-                let client_cert_pass = rustls_pemfile::private_key(
-                    &mut client_cert_pass.as_bytes(),
-                )?
-                .ok_or_else(|| error::Error::InvalidConfig {
-                    path: config.path(),
-                    cause: error::ConfigError::UnknownConfigFormat {
-                        format: "Failed to parse private key".to_string(),
-                    },
-                })?;
+                let client_cert_pass =
+                    PrivateKey::from_pem_slice(client_cert_pass.as_bytes()).map_err(|_| {
+                        error::Error::InvalidConfig {
+                            path: config.path(),
+                            cause: error::ConfigError::UnknownConfigFormat {
+                                format: "Failed to parse private key".to_string(),
+                            },
+                        }
+                    })?;
 
                 log::info!(
                     "Using {} for client certificate authentication.",
@@ -352,9 +353,10 @@ impl Connection {
             }
 
             if let Some(cert_path) = config.cert_path() {
-                if let Ok(file) = File::open(cert_path) {
-                    let certificates = rustls_pemfile::certs(&mut BufReader::new(file))
-                        .collect::<Result<Vec<_>, _>>()?;
+                if let Ok(cert_iter) = Certificate::pem_file_iter(cert_path) {
+                    let certificates = cert_iter
+                        .collect::<Result<Vec<_>, _>>()
+                        .map_err(|e| Error::new(ErrorKind::InvalidData, e.to_string()))?;
                     let (added, ignored) = root_store.add_parsable_certificates(certificates);
 
                     if ignored > 0 {


### PR DESCRIPTION
## Summary

Resolves RUSTSEC-2025-0134 by migrating from the unmaintained `rustls-pemfile` crate to the `PemObject` trait in `rustls-pki-types` (available since v1.9.0).

As [noted in the advisory](https://rustsec.org/advisories/RUSTSEC-2025-0134), `rustls-pemfile` is a thin wrapper around the same PEM parsing code now included directly in `rustls-pki-types`. The project already depends on `rustls-pki-types v1.14.0` transitively through `tokio-rustls`, so this change removes a dependency rather than adding one.

## Changes

- **`Cargo.toml`**: Remove `rustls-pemfile` from `[dependencies]` and `tls-rust` feature list
- **`src/client/conn.rs`**: Replace three `rustls_pemfile` call sites with `PemObject` trait methods:
  - `rustls_pemfile::certs()` → `CertificateDer::pem_file_iter()`
  - `rustls_pemfile::private_key()` → `PrivateKeyDer::from_pem_slice()`
  - Remove unused `File` and `BufReader` imports from the `tls-rust` cfg block

Closes #277

## Test plan

- [x] `cargo check` — default features (tls-native)
- [x] `cargo check --no-default-features --features tls-rust,...` — tls-rust path
- [x] `cargo clippy --all-targets --all-features` — no new warnings
- [x] `cargo test` — 67 tests + 8 doc-tests pass
- [x] `cargo test --no-default-features` — 45 tests + 7 doc-tests pass
- [x] `git diff --check` — no whitespace issues